### PR TITLE
Pin GitHub Actions versions using pinact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      with:
+        toolchain: stable
+        override: true
+
+    - name: Check formatting
+      run: cargo fmt --check
+
+    - name: Run Clippy
+      run: cargo clippy -- -D warnings
+
+    - name: Build
+      run: cargo build
+
+    - name: Run tests
+      run: cargo test


### PR DESCRIPTION
This commit pins the versions of GitHub Actions used in the CI workflow to specific commit SHAs using the `pinact` tool.

This improves the security and reliability of the workflow by ensuring that the exact same version of each action is used every time the workflow runs.