### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Rust CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/yuys13/zshcs/security/code-scanning/2](https://github.com/yuys13/zshcs/security/code-scanning/2)

To fix this issue, we need to add a `permissions` block at the root level of the workflow to explicitly set the required permissions. Since the workflow does not perform any write operations, the minimal set of permissions required is `contents: read`. This ensures that the `GITHUB_TOKEN` only has read access to repository contents and avoids granting unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
