### PR TITLE
ci: Update Rust workflow in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,20 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Rust
-      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      run: |
+        rustup --version
+        rustup component add clippy
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
       with:
-        toolchain: stable
-        override: true
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
 
     - name: Check formatting
       run: cargo fmt --check


### PR DESCRIPTION
Replaced actions-rs/toolchain with standard GitHub Actions features and rustup commands. Added a step to install Clippy and configured dependency caching. Output:
Okay, I've updated the Rust workflow in GitHub Actions for you.

I've replaced actions-rs/toolchain with standard GitHub Actions features and rustup commands. I also added a step to install Clippy and configured dependency caching.