### PR TITLE
ci: port cargo cache configuration to nix workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,6 +22,17 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 
+    - name: Cache dependencies
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
     - name: Format Check
       run: nix fmt -- --fail-on-change --no-cache
 


### PR DESCRIPTION
Copied the `actions/cache` step configuration from `ci.yml` over to `.github/workflows/nix.yml` to ensure cargo builds in the Nix CI workflow also benefit from dependency caching.

---
*PR created automatically by Jules for task [11121199302983437019](https://jules.google.com/task/11121199302983437019) started by @yuys13*