### PR TITLE
build(nix): add yamlfmt to treefmt configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       actions:
         patterns:
           - "*"
-
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,50 +1,38 @@
 name: Rust CI
-
 permissions:
   contents: read
-
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-
 env:
   CARGO_TERM_COLOR: always
-
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-    - name: Set up Rust
-      run: |
-        rustup show
-
-    - name: Cache dependencies
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
-
-    - name: Check formatting
-      run: cargo fmt --check
-
-    - name: Run Clippy
-      run: cargo clippy --no-deps --all-targets -- -D warnings
-
-    - name: Build
-      run: cargo build
-
-    - name: Install dependencies for tests
-      run: | 
-        sudo apt-get install -y --no-install-recommends zsh
-
-    - name: Run tests
-      run: cargo test
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Rust
+        run: |
+          rustup show
+      - name: Cache dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Run Clippy
+        run: cargo clippy --no-deps --all-targets -- -D warnings
+      - name: Build
+        run: cargo build
+      - name: Install dependencies for tests
+        run: |
+          sudo apt-get install -y --no-install-recommends zsh
+      - name: Run tests
+        run: cargo test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,9 @@
 name: Coverage
-
 on:
   push:
     branches:
       - main
   pull_request:
-
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,46 +1,36 @@
 name: Nix CI
-
 permissions:
   contents: read
-
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-
 jobs:
   check:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-    - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-
-    - name: Cache dependencies
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
-
-    - name: Format Check
-      run: nix fmt -- --fail-on-change --no-cache
-
-    - name: Clippy
-      run: nix develop --command cargo clippy --no-deps --all-targets -- -D warnings
-
-    - name: Build
-      run: nix develop --command cargo build
-
-    - name: Run tests
-      run: nix develop --command cargo test
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Cache dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Format Check
+        run: nix fmt -- --fail-on-change --no-cache
+      - name: Clippy
+        run: nix develop --command cargo clippy --no-deps --all-targets -- -D warnings
+      - name: Build
+        run: nix develop --command cargo build
+      - name: Run tests
+        run: nix develop --command cargo test

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
                 enable = true;
                 package = rustToolchain;
               };
+              yamlfmt.enable = true;
             };
           };
 


### PR DESCRIPTION
This PR enables `yamlfmt` in the `treefmt` configuration to ensure all YAML files are consistently formatted. 

### Changes
- Updated `flake.nix` to enable `yamlfmt` under `treefmt.config.programs`.
- Applied formatting to existing YAML files including GitHub Actions workflows and Dependabot configuration.