### PR TITLE
build(nix): add nix to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,11 @@ updates:
       patch:
         update-types:
           - "patch"
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      nix:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description
This pull request adds the Nix package ecosystem to the Dependabot configuration.

## Changes
- Added `nix` package ecosystem to `.github/dependabot.yml`.
- Configured weekly updates for Nix dependencies.
- Grouped Nix updates for better maintainability.

## Motivation
Automating Nix dependency updates will help keep the project's build environment and development tools up to date with minimal manual intervention.