### PR TITLE
chore(nix): improve shellHook and show cargo version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,8 @@
             ];
 
             shellHook = ''
-              echo "Rust development environment loaded (flake-parts)"
+              echo "Rust development environment loaded"
+              cargo --version
             '';
           };
         };


### PR DESCRIPTION
Improved the shellHook message in flake.nix and added 'cargo --version' to confirm the environment state upon loading.