### PR TITLE
ci: add cooldown period to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 1
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:


### PR DESCRIPTION
This pull request adds a cooldown period to the Dependabot configuration for GitHub Actions.

By setting default-days to 1, we aim to reduce the frequency of automated dependency updates, allowing more time for CI/CD processes and manual reviews between updates.

Changes:
- Added cooldown configuration to the github-actions update schedule.