### PR TITLE
feat: add nix build and run support with CI verification

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -42,3 +42,5 @@ jobs:
         run: nix develop --command cargo build
       - name: Run tests
         run: nix develop --command cargo test
+      - name: Nix Build
+        run: nix build

--- a/flake.nix
+++ b/flake.nix
@@ -55,23 +55,11 @@
           packages.default = pkgs.rustPlatform.buildRustPackage {
             pname = "zshcs";
             version = "0.1.0";
-            src = ./.;
+            src = pkgs.lib.cleanSource ./.;
 
             cargoLock = {
               lockFile = ./Cargo.lock;
             };
-
-            nativeBuildInputs = [
-              pkgs.pkg-config
-            ];
-
-            buildInputs = [
-              pkgs.openssl
-            ];
-
-            nativeCheckInputs = [
-              pkgs.zsh
-            ];
 
             # Disable check phase because the tests launch a zsh subprocess
             # using zpty, which requires pty access not available in the Nix sandbox.

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A devShell for zshcs";
+  description = "zshcs - Zsh LSP server";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -50,6 +50,37 @@
               };
               yamlfmt.enable = true;
             };
+          };
+
+          packages.default = pkgs.rustPlatform.buildRustPackage {
+            pname = "zshcs";
+            version = "0.1.0";
+            src = ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+
+            nativeBuildInputs = [
+              pkgs.pkg-config
+            ];
+
+            buildInputs = [
+              pkgs.openssl
+            ];
+
+            nativeCheckInputs = [
+              pkgs.zsh
+            ];
+
+            # Disable check phase because the tests launch a zsh subprocess
+            # using zpty, which requires pty access not available in the Nix sandbox.
+            doCheck = false;
+          };
+
+          apps.default = {
+            type = "app";
+            program = "${config.packages.default}/bin/zshcs";
           };
 
           devShells.default = pkgs.mkShell {


### PR DESCRIPTION
This PR adds support for building the project with Nix and running it directly via `nix run`. It also updates the GitHub Actions CI workflow to verify the Nix build.