### PR TITLE
ci: remove cooldown from dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
       actions:
         patterns:
           - "*"
-    cooldown:
-      default-days: 1
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:


### PR DESCRIPTION
Remove manually configured cooldown setting since it's now set by default in Dependabot.