### PR TITLE
build: pin rust toolchain to 1.96.1 and configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
       nix:
         patterns:
           - "*"
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,10 @@
             overlays = [ (import inputs.rust-overlay) ];
           };
           rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          rustPlatform = pkgs.makeRustPlatform {
+            cargo = rustToolchain;
+            rustc = rustToolchain;
+          };
         in
         {
           treefmt.config = {
@@ -52,7 +56,7 @@
             };
           };
 
-          packages.default = pkgs.rustPlatform.buildRustPackage {
+          packages.default = rustPlatform.buildRustPackage {
             pname = "zshcs";
             version = "0.1.0";
             src = pkgs.lib.cleanSource ./.;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.96.1"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
 profile = "minimal"


### PR DESCRIPTION
Pin Rust toolchain to 1.96.1, align Nix devShell and packages build environments to use it, and add rust-toolchain package-ecosystem update config in dependabot.yml.