### PR TITLE
fix(flake): add meta.description to default app and update description

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "zshcs - Zsh LSP server";
+  description = "zshcs - Authentic Zsh completions for any LSP-compliant editor.";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -76,6 +76,7 @@
           apps.default = {
             type = "app";
             program = "${config.packages.default}/bin/zshcs";
+            meta.description = "Authentic Zsh completions for any LSP-compliant editor.";
           };
 
           devShells.default = pkgs.mkShell {


### PR DESCRIPTION
## Summary
- Added `meta.description` to `apps.default` in `flake.nix` to resolve the warning during `nix flake check --all-systems`.
- Updated top-level `description` in `flake.nix`.

## Verification
- Verified with `nix flake check --all-systems` (all checks passed without warnings).