### PR TITLE
ci: add format check step to nix workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+      - name: Format Check
+        run: nix fmt -- --ci
       - name: Flake Check
         run: nix flake check --no-build --all-systems --keep-going
   build:


### PR DESCRIPTION
Add `nix fmt -- --ci` step to Nix CI workflow.