### PR TITLE
ci: add aarch64-linux to nix ci workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -21,7 +21,7 @@ jobs:
     needs: flake-check
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary
- Added `ubuntu-24.04-arm` to matrix.os in `.github/workflows/nix.yml` to enable `aarch64-linux` builds and tests in Nix CI.

## Verification
- Verified that `nix flake check` succeeds for all systems (`x86_64-linux`, `aarch64-linux`, `aarch64-darwin`).
- Verified local pre-commit checks (`cargo fmt`, `cargo clippy`, `cargo test`).