### PR TITLE
chore: add /result to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/result


### PR DESCRIPTION
Add Nix build artifact directory (`/result`) to .gitignore.