### PR TITLE
refactor(tests): use rstest for parameterized unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +76,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -81,7 +90,7 @@ checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -97,6 +106,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -204,6 +219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,10 +254,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "httparse"
@@ -349,6 +382,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -499,6 +542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +584,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.106",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +675,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -736,6 +868,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -948,6 +1110,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1221,7 @@ dependencies = [
  "dashmap 6.2.1",
  "futures",
  "lsp-types 0.97.0",
+ "rstest",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ lsp-types = "0.97" # Added to reference types in test code
 futures = "0.3" # Added for asynchronous processing in tests
 dashmap = "6.2.1"
 tempfile = "3.27.0"
+
+[dev-dependencies]
+rstest = "0.25.0"

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -125,469 +125,338 @@ pub fn parse_candidate_line(line: &str, items: &mut Vec<CompletionItem>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn test_parse_candidate_line() {
+    #[rstest]
+    // 1. Only candidate without tab
+    #[case("git status", "git status", None)]
+    // 2. Candidate with tab and description
+    #[case(
+        "status\tshow working tree status",
+        "status",
+        Some("show working tree status")
+    )]
+    // 3. Candidate with tab but empty or whitespace description
+    #[case("status\t   ", "status", None)]
+    // 4. Multiple tabs in description
+    #[case("foo\tbar\tbaz", "foo", Some("bar\tbaz"))]
+    fn test_parse_candidate_line(
+        #[case] input: &str,
+        #[case] expected_label: &str,
+        #[case] expected_detail: Option<&str>,
+    ) {
         let mut items = Vec::new();
-
-        // 1. Only candidate without tab
-        parse_candidate_line("git status", &mut items);
+        parse_candidate_line(input, &mut items);
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "git status");
-        assert_eq!(items[0].detail, None);
-
-        items.clear();
-
-        // 2. Candidate with tab and description
-        parse_candidate_line("status\tshow working tree status", &mut items);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "status");
-        assert_eq!(items[0].detail.as_deref(), Some("show working tree status"));
-
-        items.clear();
-
-        // 3. Candidate with tab but empty or whitespace description
-        parse_candidate_line("status\t   ", &mut items);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "status");
-        assert_eq!(items[0].detail, None);
-
-        items.clear();
-
-        // 4. Multiple tabs in description
-        parse_candidate_line("foo\tbar\tbaz", &mut items);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "foo");
-        assert_eq!(items[0].detail.as_deref(), Some("bar\tbaz"));
+        assert_eq!(items[0].label, expected_label);
+        assert_eq!(items[0].detail.as_deref(), expected_detail);
     }
 
-    #[test]
-    fn test_parse_candidate_line_empty_and_whitespace() {
+    #[rstest]
+    // 1. Empty string
+    #[case("", "", None, Some(""), Some(CompletionItemKind::TEXT))]
+    // 2. Whitespace only
+    #[case("   ", "   ", None, Some("   "), Some(CompletionItemKind::TEXT))]
+    // 3. Single tab only
+    #[case("\t", "", None, Some(""), Some(CompletionItemKind::TEXT))]
+    // 4. Tab with whitespace
+    #[case("\t   ", "", None, Some(""), Some(CompletionItemKind::TEXT))]
+    #[case("   \t   ", "   ", None, Some("   "), Some(CompletionItemKind::TEXT))]
+    // 5. Consecutive tabs only
+    #[case("\t\t", "", None, Some(""), Some(CompletionItemKind::TEXT))]
+    #[case("\t\t\t", "", None, Some(""), Some(CompletionItemKind::TEXT))]
+    // 6. Empty label with description
+    #[case(
+        "\tdescription only",
+        "",
+        Some("description only"),
+        Some(""),
+        Some(CompletionItemKind::TEXT)
+    )]
+    fn test_parse_candidate_line_empty_and_whitespace(
+        #[case] input: &str,
+        #[case] expected_label: &str,
+        #[case] expected_detail: Option<&str>,
+        #[case] expected_insert_text: Option<&str>,
+        #[case] expected_kind: Option<CompletionItemKind>,
+    ) {
         let mut items = Vec::new();
-
-        // 1. Empty string
-        parse_candidate_line("", &mut items);
+        parse_candidate_line(input, &mut items);
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "");
-        assert_eq!(items[0].detail, None);
-        assert_eq!(items[0].insert_text.as_deref(), Some(""));
-        assert_eq!(items[0].kind, Some(CompletionItemKind::TEXT));
-
-        items.clear();
-
-        // 2. Whitespace only
-        parse_candidate_line("   ", &mut items);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "   ");
-        assert_eq!(items[0].detail, None);
-
-        items.clear();
-
-        // 3. Single tab only
-        parse_candidate_line("\t", &mut items);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "");
-        assert_eq!(items[0].detail, None);
-
-        items.clear();
-
-        // 4. Tab with whitespace
-        parse_candidate_line("\t   ", &mut items);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "");
-        assert_eq!(items[0].detail, None);
-
-        items.clear();
-
-        parse_candidate_line("   \t   ", &mut items);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "   ");
-        assert_eq!(items[0].detail, None);
-
-        items.clear();
-
-        // 5. Consecutive tabs only
-        parse_candidate_line("\t\t", &mut items);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "");
-        assert_eq!(items[0].detail, None);
-
-        items.clear();
-
-        parse_candidate_line("\t\t\t", &mut items);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "");
-        assert_eq!(items[0].detail, None);
-
-        items.clear();
-
-        // 6. Empty label with description
-        parse_candidate_line("\tdescription only", &mut items);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "");
-        assert_eq!(items[0].detail.as_deref(), Some("description only"));
+        assert_eq!(items[0].label, expected_label);
+        assert_eq!(items[0].detail.as_deref(), expected_detail);
+        assert_eq!(items[0].insert_text.as_deref(), expected_insert_text);
+        assert_eq!(items[0].kind, expected_kind);
     }
 
-    #[test]
-    fn test_parse_candidate_line_leading_trailing_spaces() {
+    #[rstest]
+    // Leading whitespace in label
+    #[case("  status\tdesc", "  status", Some("desc"))]
+    // Trailing whitespace in label
+    #[case("status  \tdesc", "status  ", Some("desc"))]
+    // Both leading and trailing in label
+    #[case("  cmd  \tdesc", "  cmd  ", Some("desc"))]
+    // Preserving leading and trailing spaces in detail
+    #[case(
+        "status\t  detailed description  ",
+        "status",
+        Some("  detailed description  ")
+    )]
+    // Trailing tab only
+    #[case("status\t", "status", None)]
+    // Without tab, spaces preserved
+    #[case("  leading and trailing  ", "  leading and trailing  ", None)]
+    fn test_parse_candidate_line_leading_trailing_spaces(
+        #[case] input: &str,
+        #[case] expected_label: &str,
+        #[case] expected_detail: Option<&str>,
+    ) {
         let mut items = Vec::new();
-
-        // Leading whitespace in label
-        parse_candidate_line("  status\tdesc", &mut items);
-        assert_eq!(items[0].label, "  status");
-        assert_eq!(items[0].detail.as_deref(), Some("desc"));
-
-        items.clear();
-
-        // Trailing whitespace in label
-        parse_candidate_line("status  \tdesc", &mut items);
-        assert_eq!(items[0].label, "status  ");
-        assert_eq!(items[0].detail.as_deref(), Some("desc"));
-
-        items.clear();
-
-        // Both leading and trailing in label
-        parse_candidate_line("  cmd  \tdesc", &mut items);
-        assert_eq!(items[0].label, "  cmd  ");
-        assert_eq!(items[0].detail.as_deref(), Some("desc"));
-
-        items.clear();
-
-        // Preserving leading and trailing spaces in detail
-        parse_candidate_line("status\t  detailed description  ", &mut items);
-        assert_eq!(items[0].label, "status");
-        assert_eq!(items[0].detail.as_deref(), Some("  detailed description  "));
-
-        items.clear();
-
-        // Trailing tab only
-        parse_candidate_line("status\t", &mut items);
-        assert_eq!(items[0].label, "status");
-        assert_eq!(items[0].detail, None);
-
-        items.clear();
-
-        // Without tab, spaces preserved
-        parse_candidate_line("  leading and trailing  ", &mut items);
-        assert_eq!(items[0].label, "  leading and trailing  ");
-        assert_eq!(items[0].detail, None);
-    }
-
-    #[test]
-    fn test_parse_candidate_line_tab_delimiters() {
-        let mut items = Vec::new();
-
-        // Consecutive tabs with description
-        parse_candidate_line("status\t\tdesc", &mut items);
+        parse_candidate_line(input, &mut items);
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "status");
-        assert_eq!(items[0].detail.as_deref(), Some("\tdesc"));
+        assert_eq!(items[0].label, expected_label);
+        assert_eq!(items[0].detail.as_deref(), expected_detail);
+    }
 
-        items.clear();
-
-        // Multiple tabs in description
-        parse_candidate_line("part1\tpart2\tpart3", &mut items);
+    #[rstest]
+    // Consecutive tabs with description
+    #[case("status\t\tdesc", "status", Some("\tdesc"))]
+    // Multiple tabs in description
+    #[case("part1\tpart2\tpart3", "part1", Some("part2\tpart3"))]
+    // Many tabs in description
+    #[case("cmd\topt1\topt2\topt3\topt4", "cmd", Some("opt1\topt2\topt3\topt4"))]
+    fn test_parse_candidate_line_tab_delimiters(
+        #[case] input: &str,
+        #[case] expected_label: &str,
+        #[case] expected_detail: Option<&str>,
+    ) {
+        let mut items = Vec::new();
+        parse_candidate_line(input, &mut items);
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "part1");
-        assert_eq!(items[0].detail.as_deref(), Some("part2\tpart3"));
+        assert_eq!(items[0].label, expected_label);
+        assert_eq!(items[0].detail.as_deref(), expected_detail);
+    }
 
-        items.clear();
-
-        // Many tabs in description
-        parse_candidate_line("cmd\topt1\topt2\topt3\topt4", &mut items);
+    #[rstest]
+    // Double and single quotes
+    #[case(
+        "\"double quoted\"\t'single quoted' desc",
+        "\"double quoted\"",
+        Some("'single quoted' desc")
+    )]
+    // Backslashes
+    #[case("path\\to\\file\tdesc\\path", "path\\to\\file", Some("desc\\path"))]
+    // Escaped quotes
+    #[case("escaped\\\"quote\\\"\tdesc", "escaped\\\"quote\\\"", Some("desc"))]
+    // Single quote label, double quote desc
+    #[case("'single'\t\"double\"", "'single'", Some("\"double\""))]
+    fn test_parse_candidate_line_quotes_and_escapes(
+        #[case] input: &str,
+        #[case] expected_label: &str,
+        #[case] expected_detail: Option<&str>,
+    ) {
+        let mut items = Vec::new();
+        parse_candidate_line(input, &mut items);
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label, "cmd");
-        assert_eq!(items[0].detail.as_deref(), Some("opt1\topt2\topt3\topt4"));
+        assert_eq!(items[0].label, expected_label);
+        assert_eq!(items[0].detail.as_deref(), expected_detail);
     }
 
-    #[test]
-    fn test_parse_candidate_line_quotes_and_escapes() {
+    #[rstest]
+    // Environment variables and parameter expansions
+    #[case("$VAR\tenvironment variable", "$VAR", Some("environment variable"))]
+    #[case(
+        "${VAR:-default}\tparameter expansion",
+        "${VAR:-default}",
+        Some("parameter expansion")
+    )]
+    // Globs and braces
+    #[case("*.tar.gz\tglob pattern", "*.tar.gz", Some("glob pattern"))]
+    #[case("{a,b,c}\tbrace expansion", "{a,b,c}", Some("brace expansion"))]
+    #[case("[0-9]*.txt\trange glob", "[0-9]*.txt", Some("range glob"))]
+    // Pipes, redirects, and background
+    #[case("cmd1 | cmd2\tpipeline", "cmd1 | cmd2", Some("pipeline"))]
+    #[case("cmd &\tbackground", "cmd &", Some("background"))]
+    #[case("cmd1; cmd2\tseparator", "cmd1; cmd2", Some("separator"))]
+    #[case("cmd1 && cmd2\tand operator", "cmd1 && cmd2", Some("and operator"))]
+    #[case(">out.log\tredirect stdout", ">out.log", Some("redirect stdout"))]
+    #[case("2>&1\tredirect stderr", "2>&1", Some("redirect stderr"))]
+    // Subshells and process substitution
+    #[case("<(cmd)\tprocess substitution", "<(cmd)", Some("process substitution"))]
+    #[case("$(whoami)\tsubshell", "$(whoami)", Some("subshell"))]
+    #[case("`pwd`\tbacktick", "`pwd`", Some("backtick"))]
+    // Flags and options
+    #[case("-o:fmt\tcolon flag", "-o:fmt", Some("colon flag"))]
+    #[case("--opt=val\tequals flag", "--opt=val", Some("equals flag"))]
+    #[case("~/.zshrc\ttilde path", "~/.zshrc", Some("tilde path"))]
+    fn test_parse_candidate_line_shell_metacharacters(
+        #[case] input: &str,
+        #[case] expected_label: &str,
+        #[case] expected_detail: Option<&str>,
+    ) {
         let mut items = Vec::new();
-
-        // Double and single quotes
-        parse_candidate_line("\"double quoted\"\t'single quoted' desc", &mut items);
-        assert_eq!(items[0].label, "\"double quoted\"");
-        assert_eq!(items[0].detail.as_deref(), Some("'single quoted' desc"));
-
-        items.clear();
-
-        // Backslashes
-        parse_candidate_line("path\\to\\file\tdesc\\path", &mut items);
-        assert_eq!(items[0].label, "path\\to\\file");
-        assert_eq!(items[0].detail.as_deref(), Some("desc\\path"));
-
-        items.clear();
-
-        // Escaped quotes
-        parse_candidate_line("escaped\\\"quote\\\"\tdesc", &mut items);
-        assert_eq!(items[0].label, "escaped\\\"quote\\\"");
-        assert_eq!(items[0].detail.as_deref(), Some("desc"));
-
-        items.clear();
-
-        // Single quote label, double quote desc
-        parse_candidate_line("'single'\t\"double\"", &mut items);
-        assert_eq!(items[0].label, "'single'");
-        assert_eq!(items[0].detail.as_deref(), Some("\"double\""));
+        parse_candidate_line(input, &mut items);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].label, expected_label);
+        assert_eq!(items[0].detail.as_deref(), expected_detail);
     }
 
-    #[test]
-    fn test_parse_candidate_line_shell_metacharacters() {
+    #[rstest]
+    // ANSI color in label
+    #[case(
+        "\x1b[32m--verbose\x1b[0m\tenable verbose",
+        "\x1b[32m--verbose\x1b[0m",
+        Some("enable verbose")
+    )]
+    // ANSI color in detail
+    #[case(
+        "--color\t\x1b[1mcolored description\x1b[0m",
+        "--color",
+        Some("\x1b[1mcolored description\x1b[0m")
+    )]
+    // Protocol control character literal
+    #[case("\x01EOC\x01\tmarker in label", "\x01EOC\x01", Some("marker in label"))]
+    fn test_parse_candidate_line_ansi_escapes(
+        #[case] input: &str,
+        #[case] expected_label: &str,
+        #[case] expected_detail: Option<&str>,
+    ) {
         let mut items = Vec::new();
-
-        // Environment variables and parameter expansions
-        parse_candidate_line("$VAR\tenvironment variable", &mut items);
-        assert_eq!(items[0].label, "$VAR");
-        assert_eq!(items[0].detail.as_deref(), Some("environment variable"));
-
-        items.clear();
-
-        parse_candidate_line("${VAR:-default}\tparameter expansion", &mut items);
-        assert_eq!(items[0].label, "${VAR:-default}");
-        assert_eq!(items[0].detail.as_deref(), Some("parameter expansion"));
-
-        items.clear();
-
-        // Globs and braces
-        parse_candidate_line("*.tar.gz\tglob pattern", &mut items);
-        assert_eq!(items[0].label, "*.tar.gz");
-        assert_eq!(items[0].detail.as_deref(), Some("glob pattern"));
-
-        items.clear();
-
-        parse_candidate_line("{a,b,c}\tbrace expansion", &mut items);
-        assert_eq!(items[0].label, "{a,b,c}");
-        assert_eq!(items[0].detail.as_deref(), Some("brace expansion"));
-
-        items.clear();
-
-        parse_candidate_line("[0-9]*.txt\trange glob", &mut items);
-        assert_eq!(items[0].label, "[0-9]*.txt");
-        assert_eq!(items[0].detail.as_deref(), Some("range glob"));
-
-        items.clear();
-
-        // Pipes, redirects, and background
-        parse_candidate_line("cmd1 | cmd2\tpipeline", &mut items);
-        assert_eq!(items[0].label, "cmd1 | cmd2");
-        assert_eq!(items[0].detail.as_deref(), Some("pipeline"));
-
-        items.clear();
-
-        parse_candidate_line("cmd &\tbackground", &mut items);
-        assert_eq!(items[0].label, "cmd &");
-        assert_eq!(items[0].detail.as_deref(), Some("background"));
-
-        items.clear();
-
-        parse_candidate_line("cmd1; cmd2\tseparator", &mut items);
-        assert_eq!(items[0].label, "cmd1; cmd2");
-        assert_eq!(items[0].detail.as_deref(), Some("separator"));
-
-        items.clear();
-
-        parse_candidate_line("cmd1 && cmd2\tand operator", &mut items);
-        assert_eq!(items[0].label, "cmd1 && cmd2");
-        assert_eq!(items[0].detail.as_deref(), Some("and operator"));
-
-        items.clear();
-
-        parse_candidate_line(">out.log\tredirect stdout", &mut items);
-        assert_eq!(items[0].label, ">out.log");
-        assert_eq!(items[0].detail.as_deref(), Some("redirect stdout"));
-
-        items.clear();
-
-        parse_candidate_line("2>&1\tredirect stderr", &mut items);
-        assert_eq!(items[0].label, "2>&1");
-        assert_eq!(items[0].detail.as_deref(), Some("redirect stderr"));
-
-        items.clear();
-
-        // Subshells and process substitution
-        parse_candidate_line("<(cmd)\tprocess substitution", &mut items);
-        assert_eq!(items[0].label, "<(cmd)");
-        assert_eq!(items[0].detail.as_deref(), Some("process substitution"));
-
-        items.clear();
-
-        parse_candidate_line("$(whoami)\tsubshell", &mut items);
-        assert_eq!(items[0].label, "$(whoami)");
-        assert_eq!(items[0].detail.as_deref(), Some("subshell"));
-
-        items.clear();
-
-        parse_candidate_line("`pwd`\tbacktick", &mut items);
-        assert_eq!(items[0].label, "`pwd`");
-        assert_eq!(items[0].detail.as_deref(), Some("backtick"));
-
-        items.clear();
-
-        // Flags and options
-        parse_candidate_line("-o:fmt\tcolon flag", &mut items);
-        assert_eq!(items[0].label, "-o:fmt");
-        assert_eq!(items[0].detail.as_deref(), Some("colon flag"));
-
-        items.clear();
-
-        parse_candidate_line("--opt=val\tequals flag", &mut items);
-        assert_eq!(items[0].label, "--opt=val");
-        assert_eq!(items[0].detail.as_deref(), Some("equals flag"));
-
-        items.clear();
-
-        parse_candidate_line("~/.zshrc\ttilde path", &mut items);
-        assert_eq!(items[0].label, "~/.zshrc");
-        assert_eq!(items[0].detail.as_deref(), Some("tilde path"));
+        parse_candidate_line(input, &mut items);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].label, expected_label);
+        assert_eq!(items[0].detail.as_deref(), expected_detail);
     }
 
-    #[test]
-    fn test_parse_candidate_line_ansi_escapes() {
+    #[rstest]
+    // CJK Japanese
+    #[case("コミット\t変更内容を記録する", "コミット", Some("変更内容を記録する"))]
+    #[case("設定ファイル.zsh\t設定の概要", "設定ファイル.zsh", Some("設定の概要"))]
+    // CJK Chinese
+    #[case("分支\t显示分支列表", "分支", Some("显示分支列表"))]
+    // CJK Korean
+    #[case("커밋\t커밋 생성", "커밋", Some("커밋 생성"))]
+    // Emojis with ZWJ and skin tones
+    #[case("✨ feat\t新機能の追加", "✨ feat", Some("新機能の追加"))]
+    #[case("🚀 deploy\tデプロイ実行", "🚀 deploy", Some("デプロイ実行"))]
+    #[case("👨‍👩‍👧‍👦 family\t家族絵文字", "👨‍👩‍👧‍👦 family", Some("家族絵文字"))]
+    #[case(
+        "👍🏽 thumbs_up\tskin tone emoji",
+        "👍🏽 thumbs_up",
+        Some("skin tone emoji")
+    )]
+    // Accents
+    #[case("café\tFrench cafe", "café", Some("French cafe"))]
+    #[case(
+        "üñîçødé\tcombining and accents",
+        "üñîçødé",
+        Some("combining and accents")
+    )]
+    // RTL
+    #[case("مرحبا\tArabic greeting", "مرحبا", Some("Arabic greeting"))]
+    #[case("שלום\tHebrew greeting", "שלום", Some("Hebrew greeting"))]
+    fn test_parse_candidate_line_multibyte_and_unicode(
+        #[case] input: &str,
+        #[case] expected_label: &str,
+        #[case] expected_detail: Option<&str>,
+    ) {
         let mut items = Vec::new();
-
-        // ANSI color in label
-        parse_candidate_line("\x1b[32m--verbose\x1b[0m\tenable verbose", &mut items);
-        assert_eq!(items[0].label, "\x1b[32m--verbose\x1b[0m");
-        assert_eq!(items[0].detail.as_deref(), Some("enable verbose"));
-
-        items.clear();
-
-        // ANSI color in detail
-        parse_candidate_line("--color\t\x1b[1mcolored description\x1b[0m", &mut items);
-        assert_eq!(items[0].label, "--color");
-        assert_eq!(
-            items[0].detail.as_deref(),
-            Some("\x1b[1mcolored description\x1b[0m")
-        );
-
-        items.clear();
-
-        // Protocol control character literal
-        parse_candidate_line("\x01EOC\x01\tmarker in label", &mut items);
-        assert_eq!(items[0].label, "\x01EOC\x01");
-        assert_eq!(items[0].detail.as_deref(), Some("marker in label"));
+        parse_candidate_line(input, &mut items);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].label, expected_label);
+        assert_eq!(items[0].detail.as_deref(), expected_detail);
     }
 
-    #[test]
-    fn test_parse_candidate_line_multibyte_and_unicode() {
+    #[rstest]
+    #[case(10_000, 10_000)]
+    #[case(10_000, 0)]
+    #[case(10, 50_000)]
+    fn test_parse_candidate_line_extremely_long(
+        #[case] label_len: usize,
+        #[case] detail_len: usize,
+    ) {
         let mut items = Vec::new();
-
-        // CJK Japanese
-        parse_candidate_line("コミット\t変更内容を記録する", &mut items);
-        assert_eq!(items[0].label, "コミット");
-        assert_eq!(items[0].detail.as_deref(), Some("変更内容を記録する"));
-
-        items.clear();
-
-        parse_candidate_line("設定ファイル.zsh\t設定の概要", &mut items);
-        assert_eq!(items[0].label, "設定ファイル.zsh");
-        assert_eq!(items[0].detail.as_deref(), Some("設定の概要"));
-
-        items.clear();
-
-        // CJK Chinese
-        parse_candidate_line("分支\t显示分支列表", &mut items);
-        assert_eq!(items[0].label, "分支");
-        assert_eq!(items[0].detail.as_deref(), Some("显示分支列表"));
-
-        items.clear();
-
-        // CJK Korean
-        parse_candidate_line("커밋\t커밋 생성", &mut items);
-        assert_eq!(items[0].label, "커밋");
-        assert_eq!(items[0].detail.as_deref(), Some("커밋 생성"));
-
-        items.clear();
-
-        // Emojis with ZWJ and skin tones
-        parse_candidate_line("✨ feat\t新機能の追加", &mut items);
-        assert_eq!(items[0].label, "✨ feat");
-        assert_eq!(items[0].detail.as_deref(), Some("新機能の追加"));
-
-        items.clear();
-
-        parse_candidate_line("🚀 deploy\tデプロイ実行", &mut items);
-        assert_eq!(items[0].label, "🚀 deploy");
-        assert_eq!(items[0].detail.as_deref(), Some("デプロイ実行"));
-
-        items.clear();
-
-        parse_candidate_line("👨‍👩‍👧‍👦 family\t家族絵文字", &mut items);
-        assert_eq!(items[0].label, "👨‍👩‍👧‍👦 family");
-        assert_eq!(items[0].detail.as_deref(), Some("家族絵文字"));
-
-        items.clear();
-
-        parse_candidate_line("👍🏽 thumbs_up\tskin tone emoji", &mut items);
-        assert_eq!(items[0].label, "👍🏽 thumbs_up");
-        assert_eq!(items[0].detail.as_deref(), Some("skin tone emoji"));
-
-        items.clear();
-
-        // Accents
-        parse_candidate_line("café\tFrench cafe", &mut items);
-        assert_eq!(items[0].label, "café");
-        assert_eq!(items[0].detail.as_deref(), Some("French cafe"));
-
-        items.clear();
-
-        parse_candidate_line("üñîçødé\tcombining and accents", &mut items);
-        assert_eq!(items[0].label, "üñîçødé");
-        assert_eq!(items[0].detail.as_deref(), Some("combining and accents"));
-
-        items.clear();
-
-        // RTL
-        parse_candidate_line("مرحبا\tArabic greeting", &mut items);
-        assert_eq!(items[0].label, "مرحبا");
-        assert_eq!(items[0].detail.as_deref(), Some("Arabic greeting"));
-
-        items.clear();
-
-        parse_candidate_line("שלום\tHebrew greeting", &mut items);
-        assert_eq!(items[0].label, "שלום");
-        assert_eq!(items[0].detail.as_deref(), Some("Hebrew greeting"));
-    }
-
-    #[test]
-    fn test_parse_candidate_line_extremely_long() {
-        let mut items = Vec::new();
-        let long_label = "a".repeat(10_000);
-        let long_detail = "b".repeat(10_000);
-        let line = format!("{}\t{}", long_label, long_detail);
+        let long_label = "a".repeat(label_len);
+        let line = if detail_len > 0 {
+            let long_detail = "b".repeat(detail_len);
+            format!("{}\t{}", long_label, long_detail)
+        } else {
+            long_label.clone()
+        };
 
         parse_candidate_line(&line, &mut items);
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].label.len(), 10_000);
+        assert_eq!(items[0].label.len(), label_len);
         assert_eq!(items[0].label, long_label);
-        assert_eq!(items[0].detail.as_deref(), Some(long_detail.as_str()));
+        if detail_len > 0 {
+            assert_eq!(items[0].detail.as_ref().map(|s| s.len()), Some(detail_len));
+        } else {
+            assert_eq!(items[0].detail, None);
+        }
     }
 
-    #[test]
-    fn test_parse_candidate_line_item_properties() {
+    #[rstest]
+    #[case(
+        "checkout\tswitch branch",
+        "checkout",
+        Some(CompletionItemKind::TEXT),
+        Some("checkout"),
+        Some("switch branch")
+    )]
+    #[case(
+        "commit",
+        "commit",
+        Some(CompletionItemKind::TEXT),
+        Some("commit"),
+        None
+    )]
+    #[case(
+        "--help\tshow help",
+        "--help",
+        Some(CompletionItemKind::TEXT),
+        Some("--help"),
+        Some("show help")
+    )]
+    fn test_parse_candidate_line_item_properties(
+        #[case] input: &str,
+        #[case] expected_label: &str,
+        #[case] expected_kind: Option<CompletionItemKind>,
+        #[case] expected_insert_text: Option<&str>,
+        #[case] expected_detail: Option<&str>,
+    ) {
         let mut items = Vec::new();
-        parse_candidate_line("checkout\tswitch branch", &mut items);
+        parse_candidate_line(input, &mut items);
         assert_eq!(items.len(), 1);
         let item = &items[0];
-        assert_eq!(item.label, "checkout");
-        assert_eq!(item.kind, Some(CompletionItemKind::TEXT));
-        assert_eq!(item.insert_text.as_deref(), Some("checkout"));
-        assert_eq!(item.detail.as_deref(), Some("switch branch"));
+        assert_eq!(item.label, expected_label);
+        assert_eq!(item.kind, expected_kind);
+        assert_eq!(item.insert_text.as_deref(), expected_insert_text);
+        assert_eq!(item.detail.as_deref(), expected_detail);
     }
 
-    #[test]
-    fn test_parse_candidate_line_accumulation() {
+    #[rstest]
+    #[case(&[], &[])]
+    #[case(&["single\tonly"], &[("single", Some("only"))])]
+    #[case(
+        &["first\tdesc1", "second\tdesc2", "third"],
+        &[("first", Some("desc1")), ("second", Some("desc2")), ("third", None)]
+    )]
+    #[case(
+        &["--flag\toption", "-v\tverbose", "subcmd"],
+        &[("--flag", Some("option")), ("-v", Some("verbose")), ("subcmd", None)]
+    )]
+    fn test_parse_candidate_line_accumulation(
+        #[case] inputs: &[&str],
+        #[case] expected: &[(&str, Option<&str>)],
+    ) {
         let mut items = Vec::new();
-        parse_candidate_line("first\tdesc1", &mut items);
-        parse_candidate_line("second\tdesc2", &mut items);
-        parse_candidate_line("third", &mut items);
-
-        assert_eq!(items.len(), 3);
-        assert_eq!(items[0].label, "first");
-        assert_eq!(items[0].detail.as_deref(), Some("desc1"));
-        assert_eq!(items[1].label, "second");
-        assert_eq!(items[1].detail.as_deref(), Some("desc2"));
-        assert_eq!(items[2].label, "third");
-        assert_eq!(items[2].detail, None);
+        for input in inputs {
+            parse_candidate_line(input, &mut items);
+        }
+        assert_eq!(items.len(), expected.len());
+        for (item, &(exp_label, exp_detail)) in items.iter().zip(expected.iter()) {
+            assert_eq!(item.label, exp_label);
+            assert_eq!(item.detail.as_deref(), exp_detail);
+        }
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -33,490 +33,244 @@ pub fn position_to_byte_offset(text: &str, position: Position) -> Option<usize> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn test_position_to_byte_offset_utf8_utf16() {
-        let text = "あa😊b";
-        // "あ" is 3 bytes, 1 utf16 code unit
-        // "a" is 1 byte, 1 utf16 code unit
-        // "😊" is 4 bytes, 2 utf16 code units (surrogate pair)
-        // "b" is 1 byte, 1 utf16 code unit
-
-        // End of "あ": char 1 -> byte 3
-        assert_eq!(position_to_byte_offset(text, Position::new(0, 1)), Some(3));
-        // End of "a": char 2 -> byte 4
-        assert_eq!(position_to_byte_offset(text, Position::new(0, 2)), Some(4));
-        // Middle of "😊" (first surrogate): char 3 -> byte 8 (end of emoji)
-        // Current implementation returns end of char if offset falls within it.
-        assert_eq!(position_to_byte_offset(text, Position::new(0, 3)), Some(8));
-        // End of "😊": char 4 -> byte 8
-        assert_eq!(position_to_byte_offset(text, Position::new(0, 4)), Some(8));
-        // End of "b": char 5 -> byte 9
-        assert_eq!(position_to_byte_offset(text, Position::new(0, 5)), Some(9));
-    }
-
-    #[test]
-    fn test_position_to_byte_offset_edge_cases() {
-        let text = "line1\nline2";
-        // Normal case
-        assert_eq!(position_to_byte_offset(text, Position::new(0, 5)), Some(5));
-        // Next line
-        assert_eq!(position_to_byte_offset(text, Position::new(1, 0)), Some(6));
-        // Non-existent line
-        assert_eq!(position_to_byte_offset(text, Position::new(2, 0)), None);
-        // Position beyond line length (should return end of line)
+    #[rstest]
+    // "あ" is 3 bytes, 1 utf16 code unit
+    // "a" is 1 byte, 1 utf16 code unit
+    // "😊" is 4 bytes, 2 utf16 code units (surrogate pair)
+    // "b" is 1 byte, 1 utf16 code unit
+    // Start of line: char 0 -> byte 0
+    #[case("あa😊b", 0, 0, Some(0))]
+    // End of "あ": char 1 -> byte 3
+    #[case("あa😊b", 0, 1, Some(3))]
+    // End of "a": char 2 -> byte 4
+    #[case("あa😊b", 0, 2, Some(4))]
+    // Middle of "😊" (first surrogate): char 3 -> byte 8 (end of emoji)
+    // Current implementation returns end of char if offset falls within it.
+    #[case("あa😊b", 0, 3, Some(8))]
+    // End of "😊": char 4 -> byte 8
+    #[case("あa😊b", 0, 4, Some(8))]
+    // End of "b": char 5 -> byte 9
+    #[case("あa😊b", 0, 5, Some(9))]
+    // Beyond line length -> clamped to end of line (byte 9)
+    #[case("あa😊b", 0, 6, Some(9))]
+    #[case("あa😊b", 0, 100, Some(9))]
+    fn test_position_to_byte_offset_utf8_utf16(
+        #[case] text: &str,
+        #[case] line: u32,
+        #[case] character: u32,
+        #[case] expected: Option<usize>,
+    ) {
         assert_eq!(
-            position_to_byte_offset(text, Position::new(0, 100)),
-            Some(5)
-        );
-        // Empty text
-        assert_eq!(position_to_byte_offset("", Position::new(0, 0)), Some(0));
-        assert_eq!(position_to_byte_offset("", Position::new(0, 1)), Some(0));
-    }
-
-    #[test]
-    fn test_position_to_byte_offset_line_endings() {
-        // 1. CRLF basic
-        let crlf_text = "hello\r\nworld";
-        assert_eq!(
-            position_to_byte_offset(crlf_text, Position::new(0, 0)),
-            Some(0)
-        );
-        assert_eq!(
-            position_to_byte_offset(crlf_text, Position::new(0, 5)),
-            Some(5)
-        );
-        assert_eq!(
-            position_to_byte_offset(crlf_text, Position::new(0, 6)),
-            Some(5)
-        ); // clamped
-        assert_eq!(
-            position_to_byte_offset(crlf_text, Position::new(1, 0)),
-            Some(7)
-        );
-        assert_eq!(
-            position_to_byte_offset(crlf_text, Position::new(1, 5)),
-            Some(12)
-        );
-        assert_eq!(
-            position_to_byte_offset(crlf_text, Position::new(2, 0)),
-            None
-        );
-
-        // 2. CRLF with trailing newline
-        let crlf_trailing = "foo\r\nbar\r\n";
-        assert_eq!(
-            position_to_byte_offset(crlf_trailing, Position::new(0, 3)),
-            Some(3)
-        );
-        assert_eq!(
-            position_to_byte_offset(crlf_trailing, Position::new(1, 0)),
-            Some(5)
-        );
-        assert_eq!(
-            position_to_byte_offset(crlf_trailing, Position::new(1, 3)),
-            Some(8)
-        );
-        assert_eq!(
-            position_to_byte_offset(crlf_trailing, Position::new(2, 0)),
-            Some(10)
-        );
-        assert_eq!(
-            position_to_byte_offset(crlf_trailing, Position::new(2, 5)),
-            Some(10)
-        );
-        assert_eq!(
-            position_to_byte_offset(crlf_trailing, Position::new(3, 0)),
-            None
-        );
-
-        // 3. LF with trailing newline
-        let lf_trailing = "foo\nbar\n";
-        assert_eq!(
-            position_to_byte_offset(lf_trailing, Position::new(0, 3)),
-            Some(3)
-        );
-        assert_eq!(
-            position_to_byte_offset(lf_trailing, Position::new(1, 0)),
-            Some(4)
-        );
-        assert_eq!(
-            position_to_byte_offset(lf_trailing, Position::new(1, 3)),
-            Some(7)
-        );
-        assert_eq!(
-            position_to_byte_offset(lf_trailing, Position::new(2, 0)),
-            Some(8)
-        );
-        assert_eq!(
-            position_to_byte_offset(lf_trailing, Position::new(3, 0)),
-            None
-        );
-
-        // 4. Mixed line endings (CRLF and LF)
-        let mixed_text = "line1\r\nline2\nline3\r\n";
-        assert_eq!(
-            position_to_byte_offset(mixed_text, Position::new(0, 5)),
-            Some(5)
-        );
-        assert_eq!(
-            position_to_byte_offset(mixed_text, Position::new(1, 0)),
-            Some(7)
-        );
-        assert_eq!(
-            position_to_byte_offset(mixed_text, Position::new(1, 5)),
-            Some(12)
-        );
-        assert_eq!(
-            position_to_byte_offset(mixed_text, Position::new(2, 0)),
-            Some(13)
-        );
-        assert_eq!(
-            position_to_byte_offset(mixed_text, Position::new(2, 5)),
-            Some(18)
-        );
-        assert_eq!(
-            position_to_byte_offset(mixed_text, Position::new(3, 0)),
-            Some(20)
-        );
-        assert_eq!(
-            position_to_byte_offset(mixed_text, Position::new(4, 0)),
-            None
-        );
-
-        // 5. Consecutive blank lines (LF)
-        let consecutive_lf = "a\n\n\nb";
-        assert_eq!(
-            position_to_byte_offset(consecutive_lf, Position::new(0, 0)),
-            Some(0)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_lf, Position::new(0, 1)),
-            Some(1)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_lf, Position::new(1, 0)),
-            Some(2)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_lf, Position::new(2, 0)),
-            Some(3)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_lf, Position::new(3, 0)),
-            Some(4)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_lf, Position::new(3, 1)),
-            Some(5)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_lf, Position::new(4, 0)),
-            None
-        );
-
-        // 6. Consecutive blank lines (CRLF)
-        let consecutive_crlf = "a\r\n\r\n\r\nb";
-        assert_eq!(
-            position_to_byte_offset(consecutive_crlf, Position::new(0, 0)),
-            Some(0)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_crlf, Position::new(0, 1)),
-            Some(1)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_crlf, Position::new(1, 0)),
-            Some(3)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_crlf, Position::new(2, 0)),
-            Some(5)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_crlf, Position::new(3, 0)),
-            Some(7)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_crlf, Position::new(3, 1)),
-            Some(8)
-        );
-        assert_eq!(
-            position_to_byte_offset(consecutive_crlf, Position::new(4, 0)),
-            None
-        );
-
-        // 7. Blank lines only
-        let blank_lf = "\n\n";
-        assert_eq!(
-            position_to_byte_offset(blank_lf, Position::new(0, 0)),
-            Some(0)
-        );
-        assert_eq!(
-            position_to_byte_offset(blank_lf, Position::new(1, 0)),
-            Some(1)
-        );
-        assert_eq!(
-            position_to_byte_offset(blank_lf, Position::new(2, 0)),
-            Some(2)
-        );
-        assert_eq!(position_to_byte_offset(blank_lf, Position::new(3, 0)), None);
-
-        let blank_crlf = "\r\n\r\n";
-        assert_eq!(
-            position_to_byte_offset(blank_crlf, Position::new(0, 0)),
-            Some(0)
-        );
-        assert_eq!(
-            position_to_byte_offset(blank_crlf, Position::new(1, 0)),
-            Some(2)
-        );
-        assert_eq!(
-            position_to_byte_offset(blank_crlf, Position::new(2, 0)),
-            Some(4)
-        );
-        assert_eq!(
-            position_to_byte_offset(blank_crlf, Position::new(3, 0)),
-            None
+            position_to_byte_offset(text, Position::new(line, character)),
+            expected
         );
     }
 
-    #[test]
-    fn test_position_to_byte_offset_multibyte_advanced() {
-        // 1. Multi-line CJK text
-        let cjk_text = "こんにちは\nカタカナ\n漢字と記号：！";
-        // Line 0: "こんにちは" (5 chars, 15 bytes, 5 utf16 units)
+    #[rstest]
+    // Normal case (start, middle, end of line 0)
+    #[case("line1\nline2", 0, 0, Some(0))]
+    #[case("line1\nline2", 0, 2, Some(2))]
+    #[case("line1\nline2", 0, 5, Some(5))]
+    // Next line (start, middle, end of line 1)
+    #[case("line1\nline2", 1, 0, Some(6))]
+    #[case("line1\nline2", 1, 2, Some(8))]
+    #[case("line1\nline2", 1, 5, Some(11))]
+    // Non-existent line
+    #[case("line1\nline2", 2, 0, None)]
+    // Position beyond line length (should return end of line)
+    #[case("line1\nline2", 0, 100, Some(5))]
+    #[case("line1\nline2", 1, 100, Some(11))]
+    // Empty text
+    #[case("", 0, 0, Some(0))]
+    #[case("", 0, 1, Some(0))]
+    // Single line without newline
+    #[case("hello world", 0, 0, Some(0))]
+    #[case("hello world", 0, 5, Some(5))]
+    #[case("hello world", 0, 11, Some(11))]
+    #[case("hello world", 0, 20, Some(11))]
+    #[case("hello world", 1, 0, None)]
+    fn test_position_to_byte_offset_edge_cases(
+        #[case] text: &str,
+        #[case] line: u32,
+        #[case] character: u32,
+        #[case] expected: Option<usize>,
+    ) {
         assert_eq!(
-            position_to_byte_offset(cjk_text, Position::new(0, 0)),
-            Some(0)
-        );
-        assert_eq!(
-            position_to_byte_offset(cjk_text, Position::new(0, 1)),
-            Some(3)
-        );
-        assert_eq!(
-            position_to_byte_offset(cjk_text, Position::new(0, 3)),
-            Some(9)
-        );
-        assert_eq!(
-            position_to_byte_offset(cjk_text, Position::new(0, 5)),
-            Some(15)
-        );
-
-        // Line 1: "カタカナ" (4 chars, 12 bytes, 4 utf16 units, line_offset = 16)
-        assert_eq!(
-            position_to_byte_offset(cjk_text, Position::new(1, 0)),
-            Some(16)
-        );
-        assert_eq!(
-            position_to_byte_offset(cjk_text, Position::new(1, 2)),
-            Some(22)
-        );
-        assert_eq!(
-            position_to_byte_offset(cjk_text, Position::new(1, 4)),
-            Some(28)
-        );
-
-        // Line 2: "漢字と記号：！" (7 chars, 21 bytes, 7 utf16 units, line_offset = 29)
-        assert_eq!(
-            position_to_byte_offset(cjk_text, Position::new(2, 0)),
-            Some(29)
-        );
-        assert_eq!(
-            position_to_byte_offset(cjk_text, Position::new(2, 7)),
-            Some(50)
-        );
-
-        // 2. Surrogate pairs SIP/SMP (e.g. '𩸽' U+29E3D, 4B utf-8, 2 utf-16)
-        let surrogate_text = "魚𩸽 (ホッケ)";
-        // '魚' (3B, 1 utf16), '𩸽' (4B, 2 utf16), ' ' (1B, 1 utf16), '(' (1B, 1 utf16), 'ホ' (3B, 1 utf16), 'ッ' (3B, 1 utf16), 'ケ' (3B, 1 utf16), ')' (1B, 1 utf16)
-        assert_eq!(
-            position_to_byte_offset(surrogate_text, Position::new(0, 0)),
-            Some(0)
-        );
-        assert_eq!(
-            position_to_byte_offset(surrogate_text, Position::new(0, 1)),
-            Some(3)
-        );
-        assert_eq!(
-            position_to_byte_offset(surrogate_text, Position::new(0, 2)),
-            Some(7)
-        ); // mid surrogate snaps to end of char
-        assert_eq!(
-            position_to_byte_offset(surrogate_text, Position::new(0, 3)),
-            Some(7)
-        );
-        assert_eq!(
-            position_to_byte_offset(surrogate_text, Position::new(0, 4)),
-            Some(8)
-        );
-        assert_eq!(
-            position_to_byte_offset(surrogate_text, Position::new(0, 8)),
-            Some(18)
-        );
-        assert_eq!(
-            position_to_byte_offset(surrogate_text, Position::new(0, 9)),
-            Some(19)
-        );
-
-        // 3. Emojis with skin tone modifiers
-        // 👍 (U+1F44D, 4B, 2 utf16) + 🏽 (U+1F3FD, 4B, 2 utf16) = 8 bytes, 4 utf16 units
-        let skin_tone_text = "👍🏽";
-        assert_eq!(
-            position_to_byte_offset(skin_tone_text, Position::new(0, 0)),
-            Some(0)
-        );
-        assert_eq!(
-            position_to_byte_offset(skin_tone_text, Position::new(0, 1)),
-            Some(4)
-        );
-        assert_eq!(
-            position_to_byte_offset(skin_tone_text, Position::new(0, 2)),
-            Some(4)
-        );
-        assert_eq!(
-            position_to_byte_offset(skin_tone_text, Position::new(0, 3)),
-            Some(8)
-        );
-        assert_eq!(
-            position_to_byte_offset(skin_tone_text, Position::new(0, 4)),
-            Some(8)
-        );
-
-        // 4. Emoji ZWJ sequences: 👨‍👩‍👧‍👦 (25 bytes, 11 utf16 units)
-        let zwj_text = "👨‍👩‍👧‍👦";
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 0)),
-            Some(0)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 1)),
-            Some(4)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 2)),
-            Some(4)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 3)),
-            Some(7)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 4)),
-            Some(11)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 5)),
-            Some(11)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 6)),
-            Some(14)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 7)),
-            Some(18)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 8)),
-            Some(18)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 9)),
-            Some(21)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 10)),
-            Some(25)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 11)),
-            Some(25)
-        );
-        assert_eq!(
-            position_to_byte_offset(zwj_text, Position::new(0, 12)),
-            Some(25)
-        );
-
-        // 5. Combining diacritical marks
-        let combining_text = "e\u{0301} and か\u{3099}";
-        // 'e' (1B, 1u), '\u{0301}' (2B, 1u), " and " (5B, 5u), 'か' (3B, 1u), '\u{3099}' (3B, 1u) -> Total: 14B, 9u
-        assert_eq!(
-            position_to_byte_offset(combining_text, Position::new(0, 0)),
-            Some(0)
-        );
-        assert_eq!(
-            position_to_byte_offset(combining_text, Position::new(0, 1)),
-            Some(1)
-        );
-        assert_eq!(
-            position_to_byte_offset(combining_text, Position::new(0, 2)),
-            Some(3)
-        );
-        assert_eq!(
-            position_to_byte_offset(combining_text, Position::new(0, 7)),
-            Some(8)
-        );
-        assert_eq!(
-            position_to_byte_offset(combining_text, Position::new(0, 8)),
-            Some(11)
-        );
-        assert_eq!(
-            position_to_byte_offset(combining_text, Position::new(0, 9)),
-            Some(14)
-        );
-        assert_eq!(
-            position_to_byte_offset(combining_text, Position::new(0, 10)),
-            Some(14)
+            position_to_byte_offset(text, Position::new(line, character)),
+            expected
         );
     }
 
-    #[test]
-    fn test_position_to_byte_offset_boundaries_and_out_of_bounds() {
-        // 1. Empty document
-        assert_eq!(position_to_byte_offset("", Position::new(0, 0)), Some(0));
-        assert_eq!(position_to_byte_offset("", Position::new(0, 1)), Some(0));
-        assert_eq!(position_to_byte_offset("", Position::new(0, 100)), Some(0));
-        assert_eq!(position_to_byte_offset("", Position::new(1, 0)), None);
-        assert_eq!(position_to_byte_offset("", Position::new(1, 1)), None);
-
-        // 2. Single char documents
-        assert_eq!(position_to_byte_offset("x", Position::new(0, 0)), Some(0));
-        assert_eq!(position_to_byte_offset("x", Position::new(0, 1)), Some(1));
-        assert_eq!(position_to_byte_offset("x", Position::new(0, 2)), Some(1));
-        assert_eq!(position_to_byte_offset("x", Position::new(1, 0)), None);
-
-        assert_eq!(position_to_byte_offset("あ", Position::new(0, 0)), Some(0));
-        assert_eq!(position_to_byte_offset("あ", Position::new(0, 1)), Some(3));
-        assert_eq!(position_to_byte_offset("あ", Position::new(0, 2)), Some(3));
-        assert_eq!(position_to_byte_offset("あ", Position::new(1, 0)), None);
-
-        assert_eq!(position_to_byte_offset("🎉", Position::new(0, 0)), Some(0));
-        assert_eq!(position_to_byte_offset("🎉", Position::new(0, 1)), Some(4));
-        assert_eq!(position_to_byte_offset("🎉", Position::new(0, 2)), Some(4));
-        assert_eq!(position_to_byte_offset("🎉", Position::new(0, 3)), Some(4));
-        assert_eq!(position_to_byte_offset("🎉", Position::new(1, 0)), None);
-
-        // 3. Out-of-bounds line numbers
-        let doc = "first\nsecond";
-        assert_eq!(position_to_byte_offset(doc, Position::new(10, 0)), None);
+    #[rstest]
+    // 1. CRLF basic
+    #[case("hello\r\nworld", 0, 0, Some(0))]
+    #[case("hello\r\nworld", 0, 5, Some(5))]
+    #[case("hello\r\nworld", 0, 6, Some(5))] // clamped
+    #[case("hello\r\nworld", 1, 0, Some(7))]
+    #[case("hello\r\nworld", 1, 5, Some(12))]
+    #[case("hello\r\nworld", 2, 0, None)]
+    // 2. CRLF with trailing newline
+    #[case("foo\r\nbar\r\n", 0, 3, Some(3))]
+    #[case("foo\r\nbar\r\n", 1, 0, Some(5))]
+    #[case("foo\r\nbar\r\n", 1, 3, Some(8))]
+    #[case("foo\r\nbar\r\n", 2, 0, Some(10))]
+    #[case("foo\r\nbar\r\n", 2, 5, Some(10))]
+    #[case("foo\r\nbar\r\n", 3, 0, None)]
+    // 3. LF with trailing newline
+    #[case("foo\nbar\n", 0, 3, Some(3))]
+    #[case("foo\nbar\n", 1, 0, Some(4))]
+    #[case("foo\nbar\n", 1, 3, Some(7))]
+    #[case("foo\nbar\n", 2, 0, Some(8))]
+    #[case("foo\nbar\n", 3, 0, None)]
+    // 4. Mixed line endings (CRLF and LF)
+    #[case("line1\r\nline2\nline3\r\n", 0, 5, Some(5))]
+    #[case("line1\r\nline2\nline3\r\n", 1, 0, Some(7))]
+    #[case("line1\r\nline2\nline3\r\n", 1, 5, Some(12))]
+    #[case("line1\r\nline2\nline3\r\n", 2, 0, Some(13))]
+    #[case("line1\r\nline2\nline3\r\n", 2, 5, Some(18))]
+    #[case("line1\r\nline2\nline3\r\n", 3, 0, Some(20))]
+    #[case("line1\r\nline2\nline3\r\n", 4, 0, None)]
+    // 5. Consecutive blank lines (LF)
+    #[case("a\n\n\nb", 0, 0, Some(0))]
+    #[case("a\n\n\nb", 0, 1, Some(1))]
+    #[case("a\n\n\nb", 1, 0, Some(2))]
+    #[case("a\n\n\nb", 2, 0, Some(3))]
+    #[case("a\n\n\nb", 3, 0, Some(4))]
+    #[case("a\n\n\nb", 3, 1, Some(5))]
+    #[case("a\n\n\nb", 4, 0, None)]
+    // 6. Consecutive blank lines (CRLF)
+    #[case("a\r\n\r\n\r\nb", 0, 0, Some(0))]
+    #[case("a\r\n\r\n\r\nb", 0, 1, Some(1))]
+    #[case("a\r\n\r\n\r\nb", 1, 0, Some(3))]
+    #[case("a\r\n\r\n\r\nb", 2, 0, Some(5))]
+    #[case("a\r\n\r\n\r\nb", 3, 0, Some(7))]
+    #[case("a\r\n\r\n\r\nb", 3, 1, Some(8))]
+    #[case("a\r\n\r\n\r\nb", 4, 0, None)]
+    // 7. Blank lines only
+    #[case("\n\n", 0, 0, Some(0))]
+    #[case("\n\n", 1, 0, Some(1))]
+    #[case("\n\n", 2, 0, Some(2))]
+    #[case("\n\n", 3, 0, None)]
+    #[case("\r\n\r\n", 0, 0, Some(0))]
+    #[case("\r\n\r\n", 1, 0, Some(2))]
+    #[case("\r\n\r\n", 2, 0, Some(4))]
+    #[case("\r\n\r\n", 3, 0, None)]
+    fn test_position_to_byte_offset_line_endings(
+        #[case] text: &str,
+        #[case] line: u32,
+        #[case] character: u32,
+        #[case] expected: Option<usize>,
+    ) {
         assert_eq!(
-            position_to_byte_offset(doc, Position::new(u32::MAX, 0)),
-            None
+            position_to_byte_offset(text, Position::new(line, character)),
+            expected
         );
-        assert_eq!(
-            position_to_byte_offset(doc, Position::new(u32::MAX, u32::MAX)),
-            None
-        );
+    }
 
-        // 4. Extreme character offsets (u32::MAX)
+    #[rstest]
+    // 1. Multi-line CJK text
+    // Line 0: "こんにちは" (5 chars, 15 bytes, 5 utf16 units)
+    #[case("こんにちは\nカタカナ\n漢字と記号：！", 0, 0, Some(0))]
+    #[case("こんにちは\nカタカナ\n漢字と記号：！", 0, 1, Some(3))]
+    #[case("こんにちは\nカタカナ\n漢字と記号：！", 0, 3, Some(9))]
+    #[case("こんにちは\nカタカナ\n漢字と記号：！", 0, 5, Some(15))]
+    // Line 1: "カタカナ" (4 chars, 12 bytes, 4 utf16 units, line_offset = 16)
+    #[case("こんにちは\nカタカナ\n漢字と記号：！", 1, 0, Some(16))]
+    #[case("こんにちは\nカタカナ\n漢字と記号：！", 1, 2, Some(22))]
+    #[case("こんにちは\nカタカナ\n漢字と記号：！", 1, 4, Some(28))]
+    // Line 2: "漢字と記号：！" (7 chars, 21 bytes, 7 utf16 units, line_offset = 29)
+    #[case("こんにちは\nカタカナ\n漢字と記号：！", 2, 0, Some(29))]
+    #[case("こんにちは\nカタカナ\n漢字と記号：！", 2, 7, Some(50))]
+    // 2. Surrogate pairs SIP/SMP (e.g. '𩸽' U+29E3D, 4B utf-8, 2 utf-16)
+    // '魚' (3B, 1 utf16), '𩸽' (4B, 2 utf16), ' ' (1B, 1 utf16), '(' (1B, 1 utf16), 'ホ' (3B, 1 utf16), 'ッ' (3B, 1 utf16), 'ケ' (3B, 1 utf16), ')' (1B, 1 utf16)
+    #[case("魚𩸽 (ホッケ)", 0, 0, Some(0))]
+    #[case("魚𩸽 (ホッケ)", 0, 1, Some(3))]
+    #[case("魚𩸽 (ホッケ)", 0, 2, Some(7))] // mid surrogate snaps to end of char
+    #[case("魚𩸽 (ホッケ)", 0, 3, Some(7))]
+    #[case("魚𩸽 (ホッケ)", 0, 4, Some(8))]
+    #[case("魚𩸽 (ホッケ)", 0, 8, Some(18))]
+    #[case("魚𩸽 (ホッケ)", 0, 9, Some(19))]
+    // 3. Emojis with skin tone modifiers
+    // 👍 (U+1F44D, 4B, 2 utf16) + 🏽 (U+1F3FD, 4B, 2 utf16) = 8 bytes, 4 utf16 units
+    #[case("👍🏽", 0, 0, Some(0))]
+    #[case("👍🏽", 0, 1, Some(4))]
+    #[case("👍🏽", 0, 2, Some(4))]
+    #[case("👍🏽", 0, 3, Some(8))]
+    #[case("👍🏽", 0, 4, Some(8))]
+    // 4. Emoji ZWJ sequences: 👨‍👩‍👧‍👦 (25 bytes, 11 utf16 units)
+    #[case("👨‍👩‍👧‍👦", 0, 0, Some(0))]
+    #[case("👨‍👩‍👧‍👦", 0, 1, Some(4))]
+    #[case("👨‍👩‍👧‍👦", 0, 2, Some(4))]
+    #[case("👨‍👩‍👧‍👦", 0, 3, Some(7))]
+    #[case("👨‍👩‍👧‍👦", 0, 4, Some(11))]
+    #[case("👨‍👩‍👧‍👦", 0, 5, Some(11))]
+    #[case("👨‍👩‍👧‍👦", 0, 6, Some(14))]
+    #[case("👨‍👩‍👧‍👦", 0, 7, Some(18))]
+    #[case("👨‍👩‍👧‍👦", 0, 8, Some(18))]
+    #[case("👨‍👩‍👧‍👦", 0, 9, Some(21))]
+    #[case("👨‍👩‍👧‍👦", 0, 10, Some(25))]
+    #[case("👨‍👩‍👧‍👦", 0, 11, Some(25))]
+    #[case("👨‍👩‍👧‍👦", 0, 12, Some(25))]
+    // 5. Combining diacritical marks
+    // 'e' (1B, 1u), '\u{0301}' (2B, 1u), " and " (5B, 5u), 'か' (3B, 1u), '\u{3099}' (3B, 1u) -> Total: 14B, 9u
+    #[case("e\u{0301} and か\u{3099}", 0, 0, Some(0))]
+    #[case("e\u{0301} and か\u{3099}", 0, 1, Some(1))]
+    #[case("e\u{0301} and か\u{3099}", 0, 2, Some(3))]
+    #[case("e\u{0301} and か\u{3099}", 0, 7, Some(8))]
+    #[case("e\u{0301} and か\u{3099}", 0, 8, Some(11))]
+    #[case("e\u{0301} and か\u{3099}", 0, 9, Some(14))]
+    #[case("e\u{0301} and か\u{3099}", 0, 10, Some(14))]
+    fn test_position_to_byte_offset_multibyte_advanced(
+        #[case] text: &str,
+        #[case] line: u32,
+        #[case] character: u32,
+        #[case] expected: Option<usize>,
+    ) {
         assert_eq!(
-            position_to_byte_offset(doc, Position::new(0, u32::MAX)),
-            Some(5)
+            position_to_byte_offset(text, Position::new(line, character)),
+            expected
         );
+    }
+
+    #[rstest]
+    // 1. Empty document
+    #[case("", 0, 0, Some(0))]
+    #[case("", 0, 1, Some(0))]
+    #[case("", 0, 100, Some(0))]
+    #[case("", 1, 0, None)]
+    #[case("", 1, 1, None)]
+    // 2. Single char documents
+    #[case("x", 0, 0, Some(0))]
+    #[case("x", 0, 1, Some(1))]
+    #[case("x", 0, 2, Some(1))]
+    #[case("x", 1, 0, None)]
+    #[case("あ", 0, 0, Some(0))]
+    #[case("あ", 0, 1, Some(3))]
+    #[case("あ", 0, 2, Some(3))]
+    #[case("あ", 1, 0, None)]
+    #[case("🎉", 0, 0, Some(0))]
+    #[case("🎉", 0, 1, Some(4))]
+    #[case("🎉", 0, 2, Some(4))]
+    #[case("🎉", 0, 3, Some(4))]
+    #[case("🎉", 1, 0, None)]
+    // 3. Out-of-bounds line numbers
+    #[case("first\nsecond", 10, 0, None)]
+    #[case("first\nsecond", u32::MAX, 0, None)]
+    #[case("first\nsecond", u32::MAX, u32::MAX, None)]
+    // 4. Extreme character offsets (u32::MAX)
+    #[case("first\nsecond", 0, u32::MAX, Some(5))]
+    #[case("first\nsecond", 1, u32::MAX, Some(12))]
+    fn test_position_to_byte_offset_boundaries_and_out_of_bounds(
+        #[case] text: &str,
+        #[case] line: u32,
+        #[case] character: u32,
+        #[case] expected: Option<usize>,
+    ) {
         assert_eq!(
-            position_to_byte_offset(doc, Position::new(1, u32::MAX)),
-            Some(12)
+            position_to_byte_offset(text, Position::new(line, character)),
+            expected
         );
     }
 }


### PR DESCRIPTION
## Summary
- Refactored unit tests with repetitive/multi-assertion blocks in `src/document.rs` and `src/completion.rs` to parameterized table-driven tests using `rstest`.
- Added `rstest = "0.25.0"` to `[dev-dependencies]` in `Cargo.toml`.

## Details
- **`src/document.rs`**: Converted position and byte offset boundary checks (including LF/CRLF, surrogate pairs, emojis, and ZWJ sequences) to `#[rstest]` with `#[case(...)]`.
- **`src/completion.rs`**: Converted `parse_candidate_line` tests (empty/whitespace, shell metacharacters, ANSI escapes, quotes) into parameterized test cases, eliminating boilerplate resets (`items.clear()`).

## Verification
- `cargo fmt --check`: passed
- `cargo clippy --no-deps --all-targets -- -D warnings`: passed (0 warnings)
- `cargo test`: passed (all 263 tests passing)