### PR TITLE
fix(completion): isolate test cache directory and adjust timeouts for CI stability

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -10,7 +10,7 @@ use crate::error::{ZshcsError, ZshcsResult};
 
 pub const CAPTURE_ZSH: &str = include_str!("../bin/capture.zsh");
 pub const ZPTYRC_ZSH: &str = include_str!("../bin/zptyrc.zsh");
-pub const DAEMON_REQUEST_TIMEOUT: Duration = Duration::from_millis(2500);
+pub const DAEMON_REQUEST_TIMEOUT: Duration = Duration::from_millis(5000);
 
 pub struct CompletionRequest {
     pub prefix: String,
@@ -26,9 +26,19 @@ struct DaemonProcess {
 }
 
 impl DaemonProcess {
-    fn spawn(script_path: &PathBuf, client: &Client) -> std::io::Result<Self> {
-        let mut child = tokio::process::Command::new("zsh")
-            .arg(script_path)
+    fn spawn(
+        script_path: &PathBuf,
+        cache_dir: Option<&PathBuf>,
+        client: &Client,
+    ) -> std::io::Result<Self> {
+        let mut cmd = tokio::process::Command::new("zsh");
+        cmd.arg(script_path);
+        if let Some(dir) = cache_dir {
+            std::fs::create_dir_all(dir)?;
+            cmd.env("ZSHCS_CACHE_DIR", dir);
+        }
+
+        let mut child = cmd
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
@@ -80,6 +90,7 @@ impl DaemonProcess {
 
 pub async fn run_completion_daemon(
     script_path: PathBuf,
+    cache_dir: Option<PathBuf>,
     mut rx: mpsc::Receiver<CompletionRequest>,
     client: Client,
 ) {
@@ -105,7 +116,7 @@ pub async fn run_completion_daemon(
 
         // Spawn daemon if not currently running
         if daemon.is_none() {
-            match DaemonProcess::spawn(&script_path, &client) {
+            match DaemonProcess::spawn(&script_path, cache_dir.as_ref(), &client) {
                 Ok(p) => {
                     daemon = Some(p);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod document;
 pub mod error;
 pub mod server;
 
+pub use completion::{CAPTURE_ZSH, ZPTYRC_ZSH};
 pub use document::{DocumentError, DocumentManager, DocumentState};
 pub use error::{ZshcsError, ZshcsResult};
 pub use server::Backend;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::time::Duration;
 
 use serde_json::Value;
@@ -32,6 +33,16 @@ impl Backend {
         capture_script: &str,
         zptyrc_script: &str,
     ) -> ZshcsResult<Self> {
+        Self::new_with_scripts_and_cache(client, capture_script, zptyrc_script, None)
+    }
+
+    /// Creates a new `Backend` instance synchronously with custom scripts and an optional cache directory.
+    pub fn new_with_scripts_and_cache(
+        client: Client,
+        capture_script: &str,
+        zptyrc_script: &str,
+        cache_dir: Option<PathBuf>,
+    ) -> ZshcsResult<Self> {
         let temp_dir = tempfile::tempdir()?;
         let capture_path = temp_dir.path().join("capture.zsh");
         let zptyrc_path = temp_dir.path().join("zptyrc.zsh");
@@ -42,7 +53,12 @@ impl Backend {
         let (tx, rx) = mpsc::channel(32);
 
         let client_clone = client.clone();
-        tokio::spawn(run_completion_daemon(capture_path, rx, client_clone));
+        tokio::spawn(run_completion_daemon(
+            capture_path,
+            cache_dir,
+            rx,
+            client_clone,
+        ));
 
         Ok(Backend {
             client,
@@ -63,6 +79,16 @@ impl Backend {
         capture_script: &str,
         zptyrc_script: &str,
     ) -> ZshcsResult<Self> {
+        Self::new_with_scripts_and_cache_async(client, capture_script, zptyrc_script, None).await
+    }
+
+    /// Creates a new `Backend` instance asynchronously with custom scripts, optional cache directory, and non-blocking async I/O.
+    pub async fn new_with_scripts_and_cache_async(
+        client: Client,
+        capture_script: &str,
+        zptyrc_script: &str,
+        cache_dir: Option<PathBuf>,
+    ) -> ZshcsResult<Self> {
         let temp_dir = tempfile::tempdir()?;
         let capture_path = temp_dir.path().join("capture.zsh");
         let zptyrc_path = temp_dir.path().join("zptyrc.zsh");
@@ -73,7 +99,12 @@ impl Backend {
         let (tx, rx) = mpsc::channel(32);
 
         let client_clone = client.clone();
-        tokio::spawn(run_completion_daemon(capture_path, rx, client_clone));
+        tokio::spawn(run_completion_daemon(
+            capture_path,
+            cache_dir,
+            rx,
+            client_clone,
+        ));
 
         Ok(Backend {
             client,
@@ -210,7 +241,7 @@ impl LanguageServer for Backend {
             return Ok(None);
         }
 
-        let output_result = timeout(Duration::from_millis(3000), rx).await;
+        let output_result = timeout(Duration::from_millis(6000), rx).await;
 
         match output_result {
             Ok(Ok(Ok(items))) => Ok(Some(CompletionResponse::Array(items))),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,7 @@ use tower_lsp::{LspService, Server};
 use zshcs::Backend;
 
 pub async fn read_message(stream: &mut DuplexStream) -> Option<String> {
-    let timeout_duration = Duration::from_secs(5);
+    let timeout_duration = Duration::from_secs(15);
 
     let result = tokio::time::timeout(timeout_duration, async {
         let mut content_length = 0;
@@ -255,8 +255,17 @@ pub fn setup_server_mock() -> (DuplexStream, tokio::task::JoinHandle<()>) {
 
 pub fn setup_server() -> (DuplexStream, tokio::task::JoinHandle<()>) {
     let (client_stream, server_stream) = tokio::io::duplex(4096);
-    let (service, client_socket) =
-        LspService::new(|client| Backend::new(client).expect("Failed to initialize test backend"));
+    let (service, client_socket) = LspService::new(|client| {
+        let temp_cache = tempfile::tempdir().expect("Failed to create test cache dir");
+        let cache_path = temp_cache.keep();
+        Backend::new_with_scripts_and_cache(
+            client,
+            zshcs::CAPTURE_ZSH,
+            zshcs::ZPTYRC_ZSH,
+            Some(cache_path),
+        )
+        .expect("Failed to initialize test backend")
+    });
 
     let server_handle = tokio::spawn(async move {
         let (server_read, server_write) = tokio::io::split(server_stream);
@@ -274,7 +283,9 @@ pub fn setup_server_with_scripts(
 ) -> (DuplexStream, tokio::task::JoinHandle<()>) {
     let (client_stream, server_stream) = tokio::io::duplex(4096);
     let (service, client_socket) = LspService::new(move |client| {
-        Backend::new_with_scripts(client, capture_script, zptyrc_script)
+        let temp_cache = tempfile::tempdir().expect("Failed to create test cache dir");
+        let cache_path = temp_cache.keep();
+        Backend::new_with_scripts_and_cache(client, capture_script, zptyrc_script, Some(cache_path))
             .expect("Failed to initialize test backend with scripts")
     });
 

--- a/tests/completion_test.rs
+++ b/tests/completion_test.rs
@@ -194,7 +194,7 @@ async fn test_daemon_crash_tolerance() {
 async fn test_daemon_timeout() {
     // Mock capture script that sleeps, preventing an immediate EOC response
     let (mut client_stream, _server_handle) = setup_server_with_scripts(
-        "#!/usr/bin/env zsh\nwhile read -r p; do sleep 5; done\n",
+        "#!/usr/bin/env zsh\nwhile read -r p; do sleep 10; done\n",
         "",
     );
     let mut test_client = common::TestClient::new(&mut client_stream);
@@ -217,7 +217,7 @@ async fn test_daemon_timeout() {
         .await;
 
     let elapsed = start.elapsed().as_millis();
-    assert!(elapsed >= 2500, "Completion should wait for the timeout");
+    assert!(elapsed >= 5000, "Completion should wait for the timeout");
 
     assert!(res.is_ok());
     assert!(res.unwrap().is_none());
@@ -1580,4 +1580,64 @@ async fn test_completion_rapid_directory_switching_stress() {
             }
         }
     }
+}
+
+#[tokio::test]
+async fn test_completion_custom_cache_directory_isolation() {
+    let custom_cache_temp = tempfile::tempdir().unwrap();
+    let custom_cache_path = custom_cache_temp.path().to_path_buf();
+
+    // Mock script that checks if ZSHCS_CACHE_DIR environment variable is passed
+    let mock_script = r#"#!/usr/bin/env zsh
+while IFS= read -r line; do
+    if [[ $line == input:* ]]; then
+        printf "cached_env:%s\tdesc\x01EOC\x01\n" "$ZSHCS_CACHE_DIR"
+    fi
+done
+"#;
+
+    let (client_stream, server_stream) = tokio::io::duplex(4096);
+    let cache_clone = custom_cache_path.clone();
+    let (service, client_socket) = tower_lsp::LspService::new(move |client| {
+        zshcs::Backend::new_with_scripts_and_cache(
+            client,
+            mock_script,
+            "",
+            Some(cache_clone.clone()),
+        )
+        .expect("Failed to initialize test backend with cache")
+    });
+
+    let _server_handle = tokio::spawn(async move {
+        let (server_read, server_write) = tokio::io::split(server_stream);
+        tower_lsp::Server::new(server_read, server_write, client_socket)
+            .serve(service)
+            .await;
+    });
+
+    let mut stream = client_stream;
+    let mut test_client = common::TestClient::new(&mut stream);
+    let doc_uri = Url::parse("file:///cache_test.zsh").unwrap();
+    test_client.init_and_open(&doc_uri, "echo ").await;
+
+    let res = test_client
+        .send_request::<request::Completion>(CompletionParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: doc_uri.clone(),
+                },
+                position: Position::new(0, 5),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+            context: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let items = get_completion_items(res);
+    assert_eq!(items.len(), 1);
+    let expected_label = format!("cached_env:{}", custom_cache_path.to_string_lossy());
+    assert_eq!(items[0].label, expected_label);
 }


### PR DESCRIPTION
## Description
Fixes flaky CI test failures on main/PR checks caused by cache file contention and tight timeouts.

### Key Changes
1. **Isolated Cache Directory for Tests**:
   - In production, `Backend::new` keeps using the shared persistent cache (`$HOME/.cache/zshcs/zsh`) for optimal caching benefits.
   - For test runners (`setup_server` / `setup_server_with_scripts`), an isolated temporary directory is passed to the backend and set via `ZSHCS_CACHE_DIR` when spawning the daemon. This completely eliminates `compdump` file corruption and race conditions during parallel test execution.
2. **Timeout Adjustments for CI Stability**:
   - Increased `DAEMON_REQUEST_TIMEOUT` from 2500ms to 5000ms to allow sufficient time for zsh `compinit` and heavy completion script loading (such as `_git`) under constrained CI runners.
   - Updated server-side completion request timeout from 3000ms to 6000ms.
   - Updated test client `read_message` timeout to 15s.
3. **Tests**:
   - Added `test_completion_custom_cache_directory_isolation` to verify custom cache directory propagation.
   - Updated `test_daemon_timeout` to test with the 5000ms duration.