### PR TITLE
feat: implement zshcs doctor health check subcommand

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -392,7 +392,7 @@ flowchart LR
    - `tests/server_test.rs` (34 tests): Tests initialize handshake, capabilities negotiation, incremental synchronization, out-of-order versions, invalid ranges, document close cleanup, and custom execution commands.
    - `tests/logging_test.rs` (8 tests): Validates tracing subscriber initialization, `stderr` log routing, stdout JSON-RPC isolation, and dynamic `ZSHCS_LOG` / `RUST_LOG` filter evaluation.
    - `tests/cli_test.rs` (22 tests): Validates CLI flag parsing (`--stdio`, `--help`, `--version`), doctor subcommand parsing, duplicate detection, and process lifecycle over stdio.
-   - `tests/doctor_test.rs` (22 tests): Validates the `doctor` health check subsystem, individual diagnostic checks (Zsh executable, zpty, zutil, cache dir permissions, capture dry-run), report formatting, and exit codes.
+   - `tests/doctor_test.rs` (24 tests): Validates the `doctor` health check subsystem, individual diagnostic checks (Zsh executable, zpty, zutil, cache dir permissions, capture dry-run), report formatting, and exit codes.
    - `tests/stress_test.rs` (20 tests): High-concurrency stress testing with 50 simultaneous clients, 10,000-candidate volume parsing, channel saturation, rapid interleaved edit/completion bursts, and deterministic PRNG fuzzing for Unicode boundaries and surrogate pairs.
 2. **Zsh Script Unit Test Harness (`tests/zsh/run_tests.zsh`)**:
    - Executes 12 standalone unit test cases validating `capture.zsh` and `zptyrc.zsh` syntax (`zsh -n`), module loading (`zsh/zpty`, `zsh/zutil`), isolated cache creation, directory synchronization helpers (`_zshcs_chdir`), `compadd` delegation and interception hooks, and pty end-to-end query processing.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -392,7 +392,7 @@ flowchart LR
    - `tests/server_test.rs` (34 tests): Tests initialize handshake, capabilities negotiation, incremental synchronization, out-of-order versions, invalid ranges, document close cleanup, and custom execution commands.
    - `tests/logging_test.rs` (8 tests): Validates tracing subscriber initialization, `stderr` log routing, stdout JSON-RPC isolation, and dynamic `ZSHCS_LOG` / `RUST_LOG` filter evaluation.
    - `tests/cli_test.rs` (22 tests): Validates CLI flag parsing (`--stdio`, `--help`, `--version`), doctor subcommand parsing, duplicate detection, and process lifecycle over stdio.
-   - `tests/doctor_test.rs` (20 tests): Validates the `doctor` health check subsystem, individual diagnostic checks (Zsh executable, zpty, zutil, cache dir permissions, capture dry-run), report formatting, and exit codes.
+   - `tests/doctor_test.rs` (22 tests): Validates the `doctor` health check subsystem, individual diagnostic checks (Zsh executable, zpty, zutil, cache dir permissions, capture dry-run), report formatting, and exit codes.
    - `tests/stress_test.rs` (20 tests): High-concurrency stress testing with 50 simultaneous clients, 10,000-candidate volume parsing, channel saturation, rapid interleaved edit/completion bursts, and deterministic PRNG fuzzing for Unicode boundaries and surrogate pairs.
 2. **Zsh Script Unit Test Harness (`tests/zsh/run_tests.zsh`)**:
    - Executes 12 standalone unit test cases validating `capture.zsh` and `zptyrc.zsh` syntax (`zsh -n`), module loading (`zsh/zpty`, `zsh/zutil`), isolated cache creation, directory synchronization helpers (`_zshcs_chdir`), `compadd` delegation and interception hooks, and pty end-to-end query processing.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ The entry point and server backend coordinate command-line argument parsing, LSP
 - **CLI Argument Parsing (`src/cli.rs`)**:
   - Employs `clap` (derive macro) to provide type-safe, declarative command-line parsing.
   - Supports standard flags: `--stdio` (default mode for stdio-based LSP communication), `--version` / `-V`, and `--help` / `-h`.
-  - Structured cleanly to accommodate future subcommand extensions (such as diagnostic health checks).
+  - Supports the `doctor` subcommand (`zshcs doctor`) to inspect runtime prerequisites and environment health.
 - **Capabilities Negotiation (`initialize`)**:
   - **Text Document Sync**: `TextDocumentSyncKind::INCREMENTAL` for fine-grained, low-latency diff synchronization.
   - **Trigger Characters**: Registers `["-", "$", "/", "~", ".", " "]` to trigger completions immediately upon typing flags, variables, directory paths, hidden files, or subcommands.
@@ -259,6 +259,53 @@ flowchart TD
 
 ---
 
+### 2.8 Diagnostic Health Check Subsystem (`src/doctor.rs`, `zshcs doctor`)
+
+`zshcs` provides a dedicated diagnostic command (`zshcs doctor`) designed to verify runtime prerequisites, shell modules, filesystem permissions, and completion engine integrity prior to LSP client integration.
+
+```mermaid
+flowchart TD
+    DoctorCmd["CLI Invocation (`zshcs doctor`)"] --> RunChecks["run_doctor_checks() (`src/doctor.rs`)"]
+    
+    subgraph Checks [Sequential Diagnostic Pipeline]
+        C1["1. check_zsh_executable<br/>• Verify `zsh` in PATH<br/>• Execute `zsh --version`<br/>• Extract version string"]
+        C2["2. check_zpty_module<br/>• Execute `zsh -c 'zmodload zsh/zpty'`<br/>• Validate pseudo-terminal support"]
+        C3["3. check_zutil_module<br/>• Execute `zsh -c 'zmodload zsh/zutil'`<br/>• Validate zparseopts support"]
+        C4["4. check_cache_directory<br/>• Resolve `$ZSHCS_CACHE_DIR` / XDG / HOME<br/>• Test `create_dir_all`<br/>• Test write permissions via temp file"]
+        C5["5. check_capture_dry_run<br/>• Write embedded scripts to temp dir<br/>• Spawn PTY subshell in worker thread<br/>• Send `input:echo \n`<br/>• Validate candidate stream & EOC (5s timeout)"]
+    end
+    
+    RunChecks --> C1 --> C2 --> C3 --> C4 --> C5
+    C5 --> BuildReport["DoctorReport Compilation<br/>• Vec&lt;CheckResult&gt;<br/>• CheckStatus: Pass [✓], Warn [!], Fail [✗]"]
+    BuildReport --> Render["DoctorReport::render<br/>• Format Pass/Fail/Warn icons & messages<br/>• Print summary count"]
+    Render --> ExitCheck{"All Checks Passed?"}
+    ExitCheck -- Yes --> Exit0["Exit Code: 0 (Success)"]
+    ExitCheck -- No --> Exit1["Exit Code: 1 (Failure)"]
+```
+
+- **Diagnostic Scope & Methodology**:
+  1. **Zsh Executable Verification (`check_zsh_executable`)**:
+     - Confirms `zsh` binary exists in the system `PATH` and is executable.
+     - Executes `zsh --version` and records the reported shell version.
+  2. **PTY Module Availability (`check_zpty_module`)**:
+     - Executes `zsh -c "zmodload zsh/zpty"` to verify dynamic module loading of `zsh/zpty`.
+     - Ensures the host environment can spawn interactive pseudo-terminals required by `capture.zsh`.
+  3. **Utility Module Availability (`check_zutil_module`)**:
+     - Executes `zsh -c "zmodload zsh/zutil"` to verify availability of `zparseopts` used for option/flag parsing in `zptyrc.zsh`.
+  4. **Isolated Cache Verification (`check_cache_directory`)**:
+     - Resolves the target cache directory with standard fallback hierarchy: `$ZSHCS_CACHE_DIR` $\to$ `$XDG_CACHE_HOME/zshcs/zsh` $\to$ `$HOME/.cache/zshcs/zsh` $\to$ temporary directory.
+     - Verifies directory creation (`std::fs::create_dir_all`) and write permissions by writing and deleting a timestamped probe file.
+  5. **Completion Engine Dry-Run (`check_capture_dry_run`)**:
+     - Writes compile-time embedded `CAPTURE_ZSH` and `ZPTYRC_ZSH` to a temporary directory.
+     - Spawns the interactive `capture.zsh` process in an isolated worker thread guarded by a 5-second timeout.
+     - Submits a test completion query (`input:echo \n`), consumes the candidate stream, verifies reception of the `\x01EOC\x01` marker, and cleanly tears down the child process.
+- **Reporting & Exit Code Semantics**:
+  - `DoctorReport` structures outcomes across `CheckStatus::Pass` (`[✓]`), `CheckStatus::Warn` (`[!]`), and `CheckStatus::Fail` (`[✗]`).
+  - Outputs a clear, formatted summary to standard output.
+  - Returns exit code `0` when all mandatory diagnostic checks pass, and exit code `1` if any check fails, allowing seamless integration into installation scripts and CI verification.
+
+---
+
 ## 3. Detailed Data Flow & Protocols
 
 ### 3.1 Completion Request Lifecycle
@@ -344,7 +391,8 @@ flowchart LR
    - `tests/completion_test.rs` (37 tests): Validates LSP completions, consecutive requests, dynamic item kinds, working directory switching, crash recovery, timeout handling, and CRLF / multibyte buffers.
    - `tests/server_test.rs` (34 tests): Tests initialize handshake, capabilities negotiation, incremental synchronization, out-of-order versions, invalid ranges, document close cleanup, and custom execution commands.
    - `tests/logging_test.rs` (8 tests): Validates tracing subscriber initialization, `stderr` log routing, stdout JSON-RPC isolation, and dynamic `ZSHCS_LOG` / `RUST_LOG` filter evaluation.
-   - `tests/cli_test.rs` (21 tests): Validates CLI flag parsing (`--stdio`, `--help`, `--version`), duplicate detection, and process lifecycle over stdio.
+   - `tests/cli_test.rs` (22 tests): Validates CLI flag parsing (`--stdio`, `--help`, `--version`), doctor subcommand parsing, duplicate detection, and process lifecycle over stdio.
+   - `tests/doctor_test.rs` (20 tests): Validates the `doctor` health check subsystem, individual diagnostic checks (Zsh executable, zpty, zutil, cache dir permissions, capture dry-run), report formatting, and exit codes.
    - `tests/stress_test.rs` (20 tests): High-concurrency stress testing with 50 simultaneous clients, 10,000-candidate volume parsing, channel saturation, rapid interleaved edit/completion bursts, and deterministic PRNG fuzzing for Unicode boundaries and surrogate pairs.
 2. **Zsh Script Unit Test Harness (`tests/zsh/run_tests.zsh`)**:
    - Executes 12 standalone unit test cases validating `capture.zsh` and `zptyrc.zsh` syntax (`zsh -n`), module loading (`zsh/zpty`, `zsh/zutil`), isolated cache creation, directory synchronization helpers (`_zshcs_chdir`), `compadd` delegation and interception hooks, and pty end-to-end query processing.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,7 +30,8 @@ pub struct Cli {
 /// Supported subcommands for `zshcs`.
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum Commands {
-    // Reserved for future subcommands (e.g. doctor, check)
+    /// Check health of the environment, zsh installation, modules, and cache
+    Doctor,
 }
 
 #[cfg(test)]
@@ -52,6 +53,14 @@ mod tests {
         let cli = Cli::try_parse_from(args).expect("Should parse with --stdio");
         assert!(cli.stdio);
         assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn test_cli_doctor_subcommand() {
+        let args = ["zshcs", "doctor"];
+        let cli = Cli::try_parse_from(args).expect("Should parse doctor subcommand");
+        assert!(!cli.stdio);
+        assert_eq!(cli.command, Some(Commands::Doctor));
     }
 
     #[test]
@@ -81,6 +90,6 @@ mod tests {
     #[test]
     fn test_cli_unexpected_positional_argument() {
         let err = Cli::try_parse_from(["zshcs", "invalid-subcommand"]).unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::UnknownArgument);
+        assert_eq!(err.kind(), ErrorKind::InvalidSubcommand);
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -186,7 +186,9 @@ fn run_command_with_timeout(
     mut cmd: Command,
     timeout: Duration,
 ) -> std::io::Result<std::process::Output> {
-    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
     let mut child = cmd.spawn()?;
     let start = std::time::Instant::now();
 
@@ -230,7 +232,13 @@ pub fn check_zsh_executable(zsh_binary: Option<&str>) -> CheckResult {
     cmd.arg("--version");
     match run_command_with_timeout(cmd, DEFAULT_COMMAND_TIMEOUT) {
         Ok(output) if output.status.success() => {
-            let version_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let stdout_str = String::from_utf8_lossy(&output.stdout);
+            let version_str = stdout_str
+                .lines()
+                .find(|l| !l.trim().is_empty())
+                .unwrap_or("")
+                .trim()
+                .to_string();
             let version = if version_str.is_empty() {
                 format!("'{}' executable found (empty version output)", bin)
             } else {
@@ -239,7 +247,13 @@ pub fn check_zsh_executable(zsh_binary: Option<&str>) -> CheckResult {
             CheckResult::new("Zsh Executable", CheckStatus::Pass, version)
         }
         Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stderr_str = String::from_utf8_lossy(&output.stderr);
+            let stderr = stderr_str
+                .lines()
+                .find(|l| !l.trim().is_empty())
+                .unwrap_or("")
+                .trim()
+                .to_string();
             let msg = if stderr.is_empty() {
                 format!("'{} --version' exited with status {}", bin, output.status)
             } else {
@@ -268,7 +282,13 @@ pub fn check_zpty_module(zsh_binary: Option<&str>) -> CheckResult {
             "Module 'zsh/zpty' loaded successfully",
         ),
         Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stderr_str = String::from_utf8_lossy(&output.stderr);
+            let stderr = stderr_str
+                .lines()
+                .find(|l| !l.trim().is_empty())
+                .unwrap_or("")
+                .trim()
+                .to_string();
             let msg = if stderr.is_empty() {
                 format!(
                     "Failed to load 'zsh/zpty' module (exit code {})",
@@ -300,7 +320,13 @@ pub fn check_zutil_module(zsh_binary: Option<&str>) -> CheckResult {
             "Module 'zsh/zutil' loaded successfully",
         ),
         Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stderr_str = String::from_utf8_lossy(&output.stderr);
+            let stderr = stderr_str
+                .lines()
+                .find(|l| !l.trim().is_empty())
+                .unwrap_or("")
+                .trim()
+                .to_string();
             let msg = if stderr.is_empty() {
                 format!(
                     "Failed to load 'zsh/zutil' module (exit code {})",
@@ -472,6 +498,17 @@ pub fn check_capture_dry_run(
             }
         };
 
+        let stderr = child.stderr.take();
+        let stderr_handle = std::thread::spawn(move || {
+            if let Some(mut err) = stderr {
+                let mut buf = String::new();
+                let _ = std::io::Read::read_to_string(&mut err, &mut buf);
+                buf
+            } else {
+                String::new()
+            }
+        });
+
         if let Ok(mut lock) = child_holder_worker.lock() {
             *lock = Some(child);
         }
@@ -479,6 +516,7 @@ pub fn check_capture_dry_run(
         if let Err(e) = stdin.write_all(b"input:echo \n") {
             let _ = tx.send(Err(format!("Failed to write input to capture script: {e}")));
             reap_worker();
+            let _ = stderr_handle.join();
             return;
         }
         let _ = stdin.flush();
@@ -505,15 +543,24 @@ pub fn check_capture_dry_run(
                 Err(e) => {
                     let _ = tx.send(Err(format!("Error reading from capture script: {e}")));
                     reap_worker();
+                    let _ = stderr_handle.join();
                     return;
                 }
             }
         }
 
         reap_worker();
+        let stderr_output = stderr_handle.join().unwrap_or_default();
+        let stderr_trimmed = stderr_output.trim();
 
         if saw_eoc {
             let _ = tx.send(Ok(candidate_count));
+        } else if !stderr_trimmed.is_empty() {
+            let first_err_line = stderr_trimmed
+                .lines()
+                .find(|l| !l.trim().is_empty())
+                .unwrap_or(stderr_trimmed);
+            let _ = tx.send(Err(format!("Capture script failed: {first_err_line}")));
         } else {
             let _ = tx.send(Err(
                 "Capture script closed stream without EOC token".to_string()

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -160,12 +160,18 @@ impl DoctorReport {
                 warn_suffix
             )?;
         } else {
+            let warn_suffix = if self.warn_count() > 0 {
+                format!(", {} warning(s)", self.warn_count())
+            } else {
+                String::new()
+            };
             writeln!(
                 writer,
-                "Result: {}/{} checks passed, {} failed. Please address the failed items above.",
+                "Result: {}/{} checks passed, {} failed{}. Please address the failed items above.",
                 self.pass_count(),
                 self.checks.len(),
-                self.fail_count()
+                self.fail_count(),
+                warn_suffix
             )?;
         }
 
@@ -173,11 +179,56 @@ impl DoctorReport {
     }
 }
 
+const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Executes a command with a timeout guard, returning an error if execution exceeds the timeout.
+fn run_command_with_timeout(
+    mut cmd: Command,
+    timeout: Duration,
+) -> std::io::Result<std::process::Output> {
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = cmd.spawn()?;
+    let start = std::time::Instant::now();
+
+    loop {
+        match child.try_wait()? {
+            Some(status) => {
+                let mut stdout = Vec::new();
+                let mut stderr = Vec::new();
+                if let Some(mut out) = child.stdout.take() {
+                    let _ = std::io::Read::read_to_end(&mut out, &mut stdout);
+                }
+                if let Some(mut err) = child.stderr.take() {
+                    let _ = std::io::Read::read_to_end(&mut err, &mut stderr);
+                }
+                return Ok(std::process::Output {
+                    status,
+                    stdout,
+                    stderr,
+                });
+            }
+            None => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        format!("Command timed out after {} seconds", timeout.as_secs()),
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+    }
+}
+
 /// Diagnoses the existence, executability, and version of the `zsh` binary.
 #[must_use]
 pub fn check_zsh_executable(zsh_binary: Option<&str>) -> CheckResult {
     let bin = zsh_binary.unwrap_or("zsh");
-    match Command::new(bin).arg("--version").output() {
+    let mut cmd = Command::new(bin);
+    cmd.arg("--version");
+    match run_command_with_timeout(cmd, DEFAULT_COMMAND_TIMEOUT) {
         Ok(output) if output.status.success() => {
             let version_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
             let version = if version_str.is_empty() {
@@ -208,7 +259,9 @@ pub fn check_zsh_executable(zsh_binary: Option<&str>) -> CheckResult {
 #[must_use]
 pub fn check_zpty_module(zsh_binary: Option<&str>) -> CheckResult {
     let bin = zsh_binary.unwrap_or("zsh");
-    match Command::new(bin).args(["-c", "zmodload zsh/zpty"]).output() {
+    let mut cmd = Command::new(bin);
+    cmd.args(["-c", "zmodload zsh/zpty"]);
+    match run_command_with_timeout(cmd, DEFAULT_COMMAND_TIMEOUT) {
         Ok(output) if output.status.success() => CheckResult::new(
             "Zpty Module",
             CheckStatus::Pass,
@@ -238,10 +291,9 @@ pub fn check_zpty_module(zsh_binary: Option<&str>) -> CheckResult {
 #[must_use]
 pub fn check_zutil_module(zsh_binary: Option<&str>) -> CheckResult {
     let bin = zsh_binary.unwrap_or("zsh");
-    match Command::new(bin)
-        .args(["-c", "zmodload zsh/zutil"])
-        .output()
-    {
+    let mut cmd = Command::new(bin);
+    cmd.args(["-c", "zmodload zsh/zutil"]);
+    match run_command_with_timeout(cmd, DEFAULT_COMMAND_TIMEOUT) {
         Ok(output) if output.status.success() => CheckResult::new(
             "Zutil Module",
             CheckStatus::Pass,
@@ -272,11 +324,11 @@ pub fn check_zutil_module(zsh_binary: Option<&str>) -> CheckResult {
 pub fn check_cache_directory(custom_cache_dir: Option<&Path>) -> CheckResult {
     let cache_dir = if let Some(dir) = custom_cache_dir {
         dir.to_path_buf()
-    } else if let Some(dir) = std::env::var_os("ZSHCS_CACHE_DIR") {
+    } else if let Some(dir) = std::env::var_os("ZSHCS_CACHE_DIR").filter(|s| !s.is_empty()) {
         PathBuf::from(dir)
-    } else if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
+    } else if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME").filter(|s| !s.is_empty()) {
         PathBuf::from(xdg).join("zshcs/zsh")
-    } else if let Some(home) = std::env::var_os("HOME") {
+    } else if let Some(home) = std::env::var_os("HOME").filter(|s| !s.is_empty()) {
         PathBuf::from(home).join(".cache/zshcs/zsh")
     } else {
         std::env::temp_dir().join("zshcs/zsh")
@@ -366,8 +418,21 @@ pub fn check_capture_dry_run(
     let bin_str = bin.to_string();
     let capture_path_buf = capture_path.clone();
     let cache_dir_buf = custom_cache_dir.map(PathBuf::from);
-
     let (tx, rx) = std::sync::mpsc::channel();
+    let child_holder = std::sync::Arc::new(std::sync::Mutex::new(None::<std::process::Child>));
+    let child_holder_worker = std::sync::Arc::clone(&child_holder);
+
+    let reap_worker = {
+        let child_holder_worker = std::sync::Arc::clone(&child_holder_worker);
+        move || {
+            if let Ok(mut lock) = child_holder_worker.lock()
+                && let Some(mut child) = lock.take()
+            {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+    };
 
     let worker = std::thread::spawn(move || {
         let mut cmd = Command::new(&bin_str);
@@ -392,6 +457,7 @@ pub fn check_capture_dry_run(
             None => {
                 let _ = tx.send(Err("Failed to open stdin to capture script".to_string()));
                 let _ = child.kill();
+                let _ = child.wait();
                 return;
             }
         };
@@ -401,13 +467,18 @@ pub fn check_capture_dry_run(
             None => {
                 let _ = tx.send(Err("Failed to open stdout from capture script".to_string()));
                 let _ = child.kill();
+                let _ = child.wait();
                 return;
             }
         };
 
+        if let Ok(mut lock) = child_holder_worker.lock() {
+            *lock = Some(child);
+        }
+
         if let Err(e) = stdin.write_all(b"input:echo \n") {
             let _ = tx.send(Err(format!("Failed to write input to capture script: {e}")));
-            let _ = child.kill();
+            reap_worker();
             return;
         }
         let _ = stdin.flush();
@@ -433,14 +504,13 @@ pub fn check_capture_dry_run(
                 }
                 Err(e) => {
                     let _ = tx.send(Err(format!("Error reading from capture script: {e}")));
-                    let _ = child.kill();
+                    reap_worker();
                     return;
                 }
             }
         }
 
-        let _ = child.kill();
-        let _ = child.wait();
+        reap_worker();
 
         if saw_eoc {
             let _ = tx.send(Ok(candidate_count));
@@ -451,7 +521,7 @@ pub fn check_capture_dry_run(
         }
     });
 
-    match rx.recv_timeout(Duration::from_secs(5)) {
+    match rx.recv_timeout(DEFAULT_COMMAND_TIMEOUT) {
         Ok(Ok(count)) => {
             let _ = worker.join();
             CheckResult::new(
@@ -466,11 +536,23 @@ pub fn check_capture_dry_run(
             let _ = worker.join();
             CheckResult::new("Capture Script Dry-Run", CheckStatus::Fail, err_msg)
         }
-        Err(_) => CheckResult::new(
-            "Capture Script Dry-Run",
-            CheckStatus::Fail,
-            "Interactive completion dry-run timed out after 5 seconds".to_string(),
-        ),
+        Err(_) => {
+            if let Ok(mut lock) = child_holder.lock()
+                && let Some(mut child) = lock.take()
+            {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            let _ = worker.join();
+            CheckResult::new(
+                "Capture Script Dry-Run",
+                CheckStatus::Fail,
+                format!(
+                    "Interactive completion dry-run timed out after {} seconds",
+                    DEFAULT_COMMAND_TIMEOUT.as_secs()
+                ),
+            )
+        }
     }
 }
 
@@ -539,5 +621,26 @@ mod tests {
         assert_eq!(r.pass_count(), 2);
         assert_eq!(r.fail_count(), 0);
         assert_eq!(r.warn_count(), 1);
+    }
+
+    #[test]
+    fn test_run_command_with_timeout_success() {
+        let mut cmd = Command::new("echo");
+        cmd.arg("hello");
+        let res = run_command_with_timeout(cmd, Duration::from_secs(2));
+        assert!(res.is_ok());
+        let output = res.unwrap();
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "hello");
+    }
+
+    #[test]
+    fn test_run_command_with_timeout_expired() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("2");
+        let res = run_command_with_timeout(cmd, Duration::from_millis(50));
+        assert!(res.is_err());
+        let err = res.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,543 @@
+//! Environment health check and diagnostic subsystem for `zshcs`.
+//!
+//! Provides automated diagnosis of runtime dependencies, shell modules,
+//! cache directory permissions, and completion capture dry-runs.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use crate::completion::{CAPTURE_ZSH, ZPTYRC_ZSH};
+
+/// Diagnostic status for an individual check item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckStatus {
+    /// The diagnostic check passed successfully.
+    Pass,
+    /// The diagnostic check encountered a non-fatal warning.
+    Warn,
+    /// The diagnostic check failed.
+    Fail,
+}
+
+impl CheckStatus {
+    /// Returns the symbol representation for formatting.
+    #[must_use]
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            CheckStatus::Pass => "[✓]",
+            CheckStatus::Warn => "[!]",
+            CheckStatus::Fail => "[✗]",
+        }
+    }
+
+    /// Returns the textual label representation for formatting.
+    #[must_use]
+    pub fn label(&self) -> &'static str {
+        match self {
+            CheckStatus::Pass => "PASS",
+            CheckStatus::Warn => "WARN",
+            CheckStatus::Fail => "FAIL",
+        }
+    }
+}
+
+/// The result of an individual diagnostic check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckResult {
+    /// Human-readable name of the diagnostic check.
+    pub name: String,
+    /// Diagnostic outcome status.
+    pub status: CheckStatus,
+    /// Detailed diagnostic message or explanation.
+    pub message: String,
+}
+
+impl CheckResult {
+    /// Creates a new `CheckResult`.
+    pub fn new(name: impl Into<String>, status: CheckStatus, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status,
+            message: message.into(),
+        }
+    }
+
+    /// Returns `true` if the check passed.
+    #[must_use]
+    pub fn is_pass(&self) -> bool {
+        self.status == CheckStatus::Pass
+    }
+
+    /// Returns `true` if the check failed.
+    #[must_use]
+    pub fn is_fail(&self) -> bool {
+        self.status == CheckStatus::Fail
+    }
+
+    /// Returns `true` if the check issued a warning.
+    #[must_use]
+    pub fn is_warn(&self) -> bool {
+        self.status == CheckStatus::Warn
+    }
+}
+
+/// Comprehensive report containing outcomes of all executed diagnostic checks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DoctorReport {
+    /// Ordered list of diagnostic check results.
+    pub checks: Vec<CheckResult>,
+}
+
+impl DoctorReport {
+    /// Creates a new `DoctorReport` from a list of `CheckResult`s.
+    #[must_use]
+    pub fn new(checks: Vec<CheckResult>) -> Self {
+        Self { checks }
+    }
+
+    /// Returns `true` if all diagnostic checks passed without failure.
+    #[must_use]
+    pub fn is_all_passed(&self) -> bool {
+        !self.checks.iter().any(|c| c.is_fail())
+    }
+
+    /// Returns the total count of passed checks.
+    #[must_use]
+    pub fn pass_count(&self) -> usize {
+        self.checks
+            .iter()
+            .filter(|c| c.status == CheckStatus::Pass)
+            .count()
+    }
+
+    /// Returns the total count of failed checks.
+    #[must_use]
+    pub fn fail_count(&self) -> usize {
+        self.checks
+            .iter()
+            .filter(|c| c.status == CheckStatus::Fail)
+            .count()
+    }
+
+    /// Returns the total count of warning checks.
+    #[must_use]
+    pub fn warn_count(&self) -> usize {
+        self.checks
+            .iter()
+            .filter(|c| c.status == CheckStatus::Warn)
+            .count()
+    }
+
+    /// Formats and renders the diagnostic report to the specified writer.
+    pub fn render<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        writeln!(writer, "zshcs doctor - Environment Health Check")?;
+        writeln!(writer)?;
+
+        for check in &self.checks {
+            writeln!(
+                writer,
+                "{} {}: {}",
+                check.status.symbol(),
+                check.name,
+                check.message
+            )?;
+        }
+
+        writeln!(writer)?;
+        if self.is_all_passed() {
+            let warn_suffix = if self.warn_count() > 0 {
+                format!(", {} warning(s)", self.warn_count())
+            } else {
+                String::new()
+            };
+            writeln!(
+                writer,
+                "Result: {}/{} checks passed{}. Your environment is ready for zshcs!",
+                self.pass_count(),
+                self.checks.len(),
+                warn_suffix
+            )?;
+        } else {
+            writeln!(
+                writer,
+                "Result: {}/{} checks passed, {} failed. Please address the failed items above.",
+                self.pass_count(),
+                self.checks.len(),
+                self.fail_count()
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Diagnoses the existence, executability, and version of the `zsh` binary.
+#[must_use]
+pub fn check_zsh_executable(zsh_binary: Option<&str>) -> CheckResult {
+    let bin = zsh_binary.unwrap_or("zsh");
+    match Command::new(bin).arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let version_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let version = if version_str.is_empty() {
+                format!("'{}' executable found (empty version output)", bin)
+            } else {
+                version_str
+            };
+            CheckResult::new("Zsh Executable", CheckStatus::Pass, version)
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let msg = if stderr.is_empty() {
+                format!("'{} --version' exited with status {}", bin, output.status)
+            } else {
+                format!("'{} --version' failed ({}): {}", bin, output.status, stderr)
+            };
+            CheckResult::new("Zsh Executable", CheckStatus::Fail, msg)
+        }
+        Err(e) => CheckResult::new(
+            "Zsh Executable",
+            CheckStatus::Fail,
+            format!("'{}' not found in PATH or failed to execute: {}", bin, e),
+        ),
+    }
+}
+
+/// Diagnoses availability of the `zsh/zpty` module.
+#[must_use]
+pub fn check_zpty_module(zsh_binary: Option<&str>) -> CheckResult {
+    let bin = zsh_binary.unwrap_or("zsh");
+    match Command::new(bin).args(["-c", "zmodload zsh/zpty"]).output() {
+        Ok(output) if output.status.success() => CheckResult::new(
+            "Zpty Module",
+            CheckStatus::Pass,
+            "Module 'zsh/zpty' loaded successfully",
+        ),
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let msg = if stderr.is_empty() {
+                format!(
+                    "Failed to load 'zsh/zpty' module (exit code {})",
+                    output.status
+                )
+            } else {
+                format!("Failed to load 'zsh/zpty' module: {}", stderr)
+            };
+            CheckResult::new("Zpty Module", CheckStatus::Fail, msg)
+        }
+        Err(e) => CheckResult::new(
+            "Zpty Module",
+            CheckStatus::Fail,
+            format!("Failed to execute '{}' to check 'zsh/zpty': {}", bin, e),
+        ),
+    }
+}
+
+/// Diagnoses availability of the `zsh/zutil` module.
+#[must_use]
+pub fn check_zutil_module(zsh_binary: Option<&str>) -> CheckResult {
+    let bin = zsh_binary.unwrap_or("zsh");
+    match Command::new(bin)
+        .args(["-c", "zmodload zsh/zutil"])
+        .output()
+    {
+        Ok(output) if output.status.success() => CheckResult::new(
+            "Zutil Module",
+            CheckStatus::Pass,
+            "Module 'zsh/zutil' loaded successfully",
+        ),
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let msg = if stderr.is_empty() {
+                format!(
+                    "Failed to load 'zsh/zutil' module (exit code {})",
+                    output.status
+                )
+            } else {
+                format!("Failed to load 'zsh/zutil' module: {}", stderr)
+            };
+            CheckResult::new("Zutil Module", CheckStatus::Fail, msg)
+        }
+        Err(e) => CheckResult::new(
+            "Zutil Module",
+            CheckStatus::Fail,
+            format!("Failed to execute '{}' to check 'zsh/zutil': {}", bin, e),
+        ),
+    }
+}
+
+/// Diagnoses the cache directory creation and write permissions.
+#[must_use]
+pub fn check_cache_directory(custom_cache_dir: Option<&Path>) -> CheckResult {
+    let cache_dir = if let Some(dir) = custom_cache_dir {
+        dir.to_path_buf()
+    } else if let Some(dir) = std::env::var_os("ZSHCS_CACHE_DIR") {
+        PathBuf::from(dir)
+    } else if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
+        PathBuf::from(xdg).join("zshcs/zsh")
+    } else if let Some(home) = std::env::var_os("HOME") {
+        PathBuf::from(home).join(".cache/zshcs/zsh")
+    } else {
+        std::env::temp_dir().join("zshcs/zsh")
+    };
+
+    if let Err(e) = std::fs::create_dir_all(&cache_dir) {
+        return CheckResult::new(
+            "Cache Directory",
+            CheckStatus::Fail,
+            format!(
+                "Failed to create cache directory '{}': {}",
+                cache_dir.display(),
+                e
+            ),
+        );
+    }
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let test_file = cache_dir.join(format!(
+        ".zshcs_doctor_write_test_{}_{}",
+        std::process::id(),
+        timestamp
+    ));
+
+    if let Err(e) = std::fs::write(&test_file, b"zshcs doctor test") {
+        return CheckResult::new(
+            "Cache Directory",
+            CheckStatus::Fail,
+            format!(
+                "Cache directory '{}' is not writable: {}",
+                cache_dir.display(),
+                e
+            ),
+        );
+    }
+
+    let _ = std::fs::remove_file(&test_file);
+
+    CheckResult::new(
+        "Cache Directory",
+        CheckStatus::Pass,
+        format!("'{}' exists and is writable", cache_dir.display()),
+    )
+}
+
+/// Performs a dry-run test of the embedded capture script and interactive completion engine.
+#[must_use]
+pub fn check_capture_dry_run(
+    zsh_binary: Option<&str>,
+    custom_cache_dir: Option<&Path>,
+) -> CheckResult {
+    let bin = zsh_binary.unwrap_or("zsh");
+
+    let temp_dir = match tempfile::tempdir() {
+        Ok(t) => t,
+        Err(e) => {
+            return CheckResult::new(
+                "Capture Script Dry-Run",
+                CheckStatus::Fail,
+                format!("Failed to create temporary directory for dry-run: {e}"),
+            );
+        }
+    };
+
+    let capture_path = temp_dir.path().join("capture.zsh");
+    let zptyrc_path = temp_dir.path().join("zptyrc.zsh");
+
+    if let Err(e) = std::fs::write(&capture_path, CAPTURE_ZSH) {
+        return CheckResult::new(
+            "Capture Script Dry-Run",
+            CheckStatus::Fail,
+            format!("Failed to write capture.zsh: {e}"),
+        );
+    }
+
+    if let Err(e) = std::fs::write(&zptyrc_path, ZPTYRC_ZSH) {
+        return CheckResult::new(
+            "Capture Script Dry-Run",
+            CheckStatus::Fail,
+            format!("Failed to write zptyrc.zsh: {e}"),
+        );
+    }
+
+    let bin_str = bin.to_string();
+    let capture_path_buf = capture_path.clone();
+    let cache_dir_buf = custom_cache_dir.map(PathBuf::from);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    let worker = std::thread::spawn(move || {
+        let mut cmd = Command::new(&bin_str);
+        cmd.arg(&capture_path_buf);
+        if let Some(ref dir) = cache_dir_buf {
+            cmd.env("ZSHCS_CACHE_DIR", dir);
+        }
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = tx.send(Err(format!("Failed to spawn {bin_str}: {e}")));
+                return;
+            }
+        };
+
+        let mut stdin = match child.stdin.take() {
+            Some(s) => s,
+            None => {
+                let _ = tx.send(Err("Failed to open stdin to capture script".to_string()));
+                let _ = child.kill();
+                return;
+            }
+        };
+
+        let stdout = match child.stdout.take() {
+            Some(s) => s,
+            None => {
+                let _ = tx.send(Err("Failed to open stdout from capture script".to_string()));
+                let _ = child.kill();
+                return;
+            }
+        };
+
+        if let Err(e) = stdin.write_all(b"input:echo \n") {
+            let _ = tx.send(Err(format!("Failed to write input to capture script: {e}")));
+            let _ = child.kill();
+            return;
+        }
+        let _ = stdin.flush();
+
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        let mut saw_eoc = false;
+        let mut candidate_count = 0;
+
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    let trimmed = line.trim_end_matches(['\r', '\n']);
+                    if trimmed.contains("\x01EOC\x01") {
+                        saw_eoc = true;
+                        break;
+                    }
+                    if !trimmed.is_empty() {
+                        candidate_count += 1;
+                    }
+                }
+                Err(e) => {
+                    let _ = tx.send(Err(format!("Error reading from capture script: {e}")));
+                    let _ = child.kill();
+                    return;
+                }
+            }
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        if saw_eoc {
+            let _ = tx.send(Ok(candidate_count));
+        } else {
+            let _ = tx.send(Err(
+                "Capture script closed stream without EOC token".to_string()
+            ));
+        }
+    });
+
+    match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(Ok(count)) => {
+            let _ = worker.join();
+            CheckResult::new(
+                "Capture Script Dry-Run",
+                CheckStatus::Pass,
+                format!(
+                    "Interactive completion engine responded successfully (received {count} candidate(s))"
+                ),
+            )
+        }
+        Ok(Err(err_msg)) => {
+            let _ = worker.join();
+            CheckResult::new("Capture Script Dry-Run", CheckStatus::Fail, err_msg)
+        }
+        Err(_) => CheckResult::new(
+            "Capture Script Dry-Run",
+            CheckStatus::Fail,
+            "Interactive completion dry-run timed out after 5 seconds".to_string(),
+        ),
+    }
+}
+
+/// Executes all standard diagnostic health checks and returns a `DoctorReport`.
+#[must_use]
+pub fn run_doctor_checks() -> DoctorReport {
+    let check1 = check_zsh_executable(None);
+    let check2 = check_zpty_module(None);
+    let check3 = check_zutil_module(None);
+    let check4 = check_cache_directory(None);
+    let check5 = check_capture_dry_run(None, None);
+
+    DoctorReport::new(vec![check1, check2, check3, check4, check5])
+}
+
+/// Executes all health checks, renders the report to the writer, and returns `true` if all passed.
+pub fn run_doctor_with_writer<W: Write>(writer: &mut W) -> bool {
+    let report = run_doctor_checks();
+    let _ = report.render(writer);
+    report.is_all_passed()
+}
+
+/// Entry point for `zshcs doctor` subcommand.
+///
+/// Executes diagnostics, writes results to stdout, and returns exit code (`0` for success, `1` on failure).
+#[must_use]
+pub fn run_doctor() -> i32 {
+    let mut stdout = std::io::stdout().lock();
+    if run_doctor_with_writer(&mut stdout) {
+        0
+    } else {
+        1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_result_helpers() {
+        let pass = CheckResult::new("Test", CheckStatus::Pass, "ok");
+        assert!(pass.is_pass());
+        assert!(!pass.is_fail());
+        assert!(!pass.is_warn());
+
+        let fail = CheckResult::new("Test", CheckStatus::Fail, "bad");
+        assert!(!fail.is_pass());
+        assert!(fail.is_fail());
+        assert!(!fail.is_warn());
+
+        let warn = CheckResult::new("Test", CheckStatus::Warn, "warn");
+        assert!(!warn.is_pass());
+        assert!(!warn.is_fail());
+        assert!(warn.is_warn());
+    }
+
+    #[test]
+    fn test_report_all_pass_calculation() {
+        let r = DoctorReport::new(vec![
+            CheckResult::new("C1", CheckStatus::Pass, "ok"),
+            CheckResult::new("C2", CheckStatus::Pass, "ok"),
+            CheckResult::new("C3", CheckStatus::Warn, "warning"),
+        ]);
+        assert!(r.is_all_passed());
+        assert_eq!(r.pass_count(), 2);
+        assert_eq!(r.fail_count(), 0);
+        assert_eq!(r.warn_count(), 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod completion;
+pub mod doctor;
 pub mod document;
 pub mod error;
 pub mod logging;
@@ -7,6 +8,11 @@ pub mod server;
 
 pub use cli::{Cli, Commands};
 pub use completion::{CAPTURE_ZSH, ZPTYRC_ZSH, infer_completion_kind};
+pub use doctor::{
+    CheckResult, CheckStatus, DoctorReport, check_cache_directory, check_capture_dry_run,
+    check_zpty_module, check_zsh_executable, check_zutil_module, run_doctor, run_doctor_checks,
+    run_doctor_with_writer,
+};
 pub use document::{DocumentError, DocumentManager, DocumentState};
 pub use error::{ZshcsError, ZshcsResult};
 pub use logging::{create_env_filter, init_logging, try_init_logging};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,16 @@
 use clap::Parser;
 use tower_lsp::{LspService, Server};
-use zshcs::{Backend, Cli, init_logging};
+use zshcs::{Backend, Cli, Commands, init_logging, run_doctor};
 
 #[tokio::main]
 async fn main() {
     init_logging();
-    let _cli = Cli::parse();
+    let cli = Cli::parse();
+
+    if let Some(Commands::Doctor) = cli.command {
+        let exit_code = run_doctor();
+        std::process::exit(exit_code);
+    }
 
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -172,6 +172,21 @@ fn test_cli_struct_traits() {
     let debug_str = format!("{cli1:?}");
     assert!(debug_str.contains("Cli"));
     assert!(debug_str.contains("stdio: true"));
+
+    let cli_doc = Cli {
+        stdio: false,
+        command: Some(zshcs::Commands::Doctor),
+    };
+    let cli_doc_clone = cli_doc.clone();
+    assert_eq!(cli_doc, cli_doc_clone);
+    assert!(format!("{cli_doc:?}").contains("Doctor"));
+}
+
+#[test]
+fn test_cli_parse_doctor_subcommand_in_cli_test() {
+    let cli = Cli::try_parse_from(["zshcs", "doctor"]).expect("Failed to parse doctor subcommand");
+    assert!(!cli.stdio);
+    assert_eq!(cli.command, Some(zshcs::Commands::Doctor));
 }
 
 #[test]
@@ -192,7 +207,7 @@ fn test_cli_parse_case_sensitivity() {
 fn test_cli_parse_empty_positional_arg() {
     let res = Cli::try_parse_from(["zshcs", ""]);
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::InvalidSubcommand);
 }
 
 #[test]

--- a/tests/doctor_test.rs
+++ b/tests/doctor_test.rs
@@ -300,3 +300,57 @@ fn test_run_doctor_function_returns_zero_exit_code() {
     let code = run_doctor();
     assert_eq!(code, 0);
 }
+
+#[test]
+fn test_doctor_report_warning_only_rendering() {
+    let checks = vec![
+        CheckResult::new("Zsh Executable", CheckStatus::Pass, "zsh 5.9"),
+        CheckResult::new("Zpty Module", CheckStatus::Pass, "module loaded"),
+        CheckResult::new(
+            "Cache Directory",
+            CheckStatus::Warn,
+            "sub-optimal directory",
+        ),
+    ];
+    let report = DoctorReport::new(checks);
+    assert!(report.is_all_passed());
+    assert_eq!(report.pass_count(), 2);
+    assert_eq!(report.fail_count(), 0);
+    assert_eq!(report.warn_count(), 1);
+
+    let mut output = Vec::new();
+    report.render(&mut output).unwrap();
+    let rendered = String::from_utf8(output).unwrap();
+
+    assert!(rendered.contains("[!] Cache Directory: sub-optimal directory"));
+    assert!(
+        rendered.contains(
+            "Result: 2/3 checks passed, 1 warning(s). Your environment is ready for zshcs!"
+        )
+    );
+}
+
+#[test]
+fn test_doctor_report_single_failure_zero_passes() {
+    let checks = vec![CheckResult::new(
+        "Zsh Executable",
+        CheckStatus::Fail,
+        "missing zsh",
+    )];
+    let report = DoctorReport::new(checks);
+    assert!(!report.is_all_passed());
+    assert_eq!(report.pass_count(), 0);
+    assert_eq!(report.fail_count(), 1);
+    assert_eq!(report.warn_count(), 0);
+
+    let mut output = Vec::new();
+    report.render(&mut output).unwrap();
+    let rendered = String::from_utf8(output).unwrap();
+
+    assert!(rendered.contains("[✗] Zsh Executable: missing zsh"));
+    assert!(
+        rendered.contains(
+            "Result: 0/1 checks passed, 1 failed. Please address the failed items above."
+        )
+    );
+}

--- a/tests/doctor_test.rs
+++ b/tests/doctor_test.rs
@@ -208,7 +208,56 @@ fn test_doctor_report_rendering_with_failures_and_warnings() {
     assert!(rendered.contains("[✓] Zsh Executable: zsh 5.9"));
     assert!(rendered.contains("[✗] Zpty Module: module not found"));
     assert!(rendered.contains("[!] Custom Check: deprecated config"));
-    assert!(rendered.contains("Result: 1/3 checks passed, 1 failed"));
+    assert!(rendered.contains("Result: 1/3 checks passed, 1 failed, 1 warning(s)"));
+}
+
+#[test]
+fn test_doctor_report_rendering_failure_without_warnings() {
+    let checks = vec![
+        CheckResult::new("Zsh Executable", CheckStatus::Pass, "zsh 5.9"),
+        CheckResult::new("Zpty Module", CheckStatus::Fail, "module not found"),
+    ];
+    let report = DoctorReport::new(checks);
+    assert!(!report.is_all_passed());
+    assert_eq!(report.pass_count(), 1);
+    assert_eq!(report.fail_count(), 1);
+    assert_eq!(report.warn_count(), 0);
+
+    let mut output = Vec::new();
+    report.render(&mut output).unwrap();
+    let rendered = String::from_utf8(output).unwrap();
+
+    assert!(rendered.contains("[✓] Zsh Executable: zsh 5.9"));
+    assert!(rendered.contains("[✗] Zpty Module: module not found"));
+    assert!(
+        rendered.contains(
+            "Result: 1/2 checks passed, 1 failed. Please address the failed items above."
+        )
+    );
+}
+
+#[test]
+fn test_check_cache_directory_empty_env_vars() {
+    let temp_dir = tempdir().unwrap();
+    let home_path = temp_dir.path().join("home");
+    std::fs::create_dir_all(&home_path).unwrap();
+
+    // Set empty strings for ZSHCS_CACHE_DIR and XDG_CACHE_HOME, valid HOME
+    unsafe {
+        std::env::set_var("ZSHCS_CACHE_DIR", "");
+        std::env::set_var("XDG_CACHE_HOME", "");
+        std::env::set_var("HOME", &home_path);
+    }
+
+    let res = check_cache_directory(None);
+    assert_eq!(res.status, CheckStatus::Pass);
+    assert_eq!(res.name, "Cache Directory");
+    assert!(home_path.join(".cache/zshcs/zsh").exists());
+
+    unsafe {
+        std::env::remove_var("ZSHCS_CACHE_DIR");
+        std::env::remove_var("XDG_CACHE_HOME");
+    }
 }
 
 #[test]

--- a/tests/doctor_test.rs
+++ b/tests/doctor_test.rs
@@ -1,0 +1,253 @@
+use clap::Parser;
+use std::process::Command;
+use tempfile::tempdir;
+use zshcs::cli::{Cli, Commands};
+use zshcs::doctor::{
+    CheckResult, CheckStatus, DoctorReport, check_cache_directory, check_capture_dry_run,
+    check_zpty_module, check_zsh_executable, check_zutil_module, run_doctor, run_doctor_checks,
+    run_doctor_with_writer,
+};
+
+#[test]
+fn test_cli_parse_doctor_subcommand() {
+    let args = ["zshcs", "doctor"];
+    let cli = Cli::try_parse_from(args).expect("Should parse 'doctor' subcommand");
+    assert_eq!(cli.command, Some(Commands::Doctor));
+    assert!(!cli.stdio);
+}
+
+#[test]
+fn test_binary_help_includes_doctor_subcommand() {
+    let bin_path = env!("CARGO_BIN_EXE_zshcs");
+    let output = Command::new(bin_path)
+        .arg("--help")
+        .output()
+        .expect("Failed to execute zshcs --help");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("doctor"),
+        "Help output should include 'doctor' subcommand"
+    );
+}
+
+#[test]
+fn test_binary_doctor_subcommand_execution() {
+    let bin_path = env!("CARGO_BIN_EXE_zshcs");
+    let output = Command::new(bin_path)
+        .arg("doctor")
+        .output()
+        .expect("Failed to execute zshcs doctor");
+
+    assert!(
+        output.status.success(),
+        "zshcs doctor should exit with code 0 on healthy environment"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("zshcs doctor - Environment Health Check"));
+    assert!(stdout.contains("Zsh Executable"));
+    assert!(stdout.contains("Zpty Module"));
+    assert!(stdout.contains("Zutil Module"));
+    assert!(stdout.contains("Cache Directory"));
+    assert!(stdout.contains("Capture Script Dry-Run"));
+    assert!(stdout.contains("5/5 checks passed"));
+}
+
+#[test]
+fn test_check_zsh_executable_success() {
+    let res = check_zsh_executable(None);
+    assert_eq!(res.status, CheckStatus::Pass);
+    assert_eq!(res.name, "Zsh Executable");
+    assert!(res.message.contains("zsh"));
+    assert!(res.is_pass());
+    assert!(!res.is_fail());
+    assert!(!res.is_warn());
+}
+
+#[test]
+fn test_check_zsh_executable_nonexistent() {
+    let res = check_zsh_executable(Some("nonexistent_zsh_binary_12345"));
+    assert_eq!(res.status, CheckStatus::Fail);
+    assert_eq!(res.name, "Zsh Executable");
+    assert!(res.is_fail());
+    assert!(!res.is_pass());
+}
+
+#[test]
+fn test_check_zpty_module_success() {
+    let res = check_zpty_module(None);
+    assert_eq!(res.status, CheckStatus::Pass);
+    assert_eq!(res.name, "Zpty Module");
+    assert!(res.message.contains("zsh/zpty"));
+}
+
+#[test]
+fn test_check_zpty_module_nonexistent_binary() {
+    let res = check_zpty_module(Some("nonexistent_zsh_binary_12345"));
+    assert_eq!(res.status, CheckStatus::Fail);
+    assert_eq!(res.name, "Zpty Module");
+}
+
+#[test]
+fn test_check_zutil_module_success() {
+    let res = check_zutil_module(None);
+    assert_eq!(res.status, CheckStatus::Pass);
+    assert_eq!(res.name, "Zutil Module");
+    assert!(res.message.contains("zsh/zutil"));
+}
+
+#[test]
+fn test_check_zutil_module_nonexistent_binary() {
+    let res = check_zutil_module(Some("nonexistent_zsh_binary_12345"));
+    assert_eq!(res.status, CheckStatus::Fail);
+    assert_eq!(res.name, "Zutil Module");
+}
+
+#[test]
+fn test_check_cache_directory_custom_tempdir() {
+    let temp_dir = tempdir().unwrap();
+    let cache_path = temp_dir.path().join("sub/dir/cache");
+
+    let res = check_cache_directory(Some(&cache_path));
+    assert_eq!(res.status, CheckStatus::Pass);
+    assert_eq!(res.name, "Cache Directory");
+    assert!(cache_path.exists());
+}
+
+#[test]
+fn test_check_cache_directory_default_env() {
+    let temp_dir = tempdir().unwrap();
+    let cache_path = temp_dir.path().join("env_cache");
+    // SAFETY: Single-threaded test execution scope for env var test
+    unsafe {
+        std::env::set_var("ZSHCS_CACHE_DIR", &cache_path);
+    }
+
+    let res = check_cache_directory(None);
+    assert_eq!(res.status, CheckStatus::Pass);
+    assert_eq!(res.name, "Cache Directory");
+    assert!(cache_path.exists());
+
+    unsafe {
+        std::env::remove_var("ZSHCS_CACHE_DIR");
+    }
+}
+
+#[test]
+fn test_check_cache_directory_permission_failure() {
+    let temp_dir = tempdir().unwrap();
+    // Create a regular file where directory creation should fail
+    let file_path = temp_dir.path().join("blocking_file");
+    std::fs::write(&file_path, b"dummy").unwrap();
+
+    let invalid_cache_path = file_path.join("uncreatable_subfolder");
+    let res = check_cache_directory(Some(&invalid_cache_path));
+    assert_eq!(res.status, CheckStatus::Fail);
+    assert_eq!(res.name, "Cache Directory");
+}
+
+#[test]
+fn test_check_capture_dry_run_success() {
+    let temp_dir = tempdir().unwrap();
+    let res = check_capture_dry_run(None, Some(temp_dir.path()));
+    assert_eq!(res.status, CheckStatus::Pass);
+    assert_eq!(res.name, "Capture Script Dry-Run");
+    assert!(
+        res.message
+            .contains("Interactive completion engine responded")
+    );
+}
+
+#[test]
+fn test_check_capture_dry_run_nonexistent_binary() {
+    let temp_dir = tempdir().unwrap();
+    let res = check_capture_dry_run(Some("nonexistent_zsh_binary_12345"), Some(temp_dir.path()));
+    assert_eq!(res.status, CheckStatus::Fail);
+    assert_eq!(res.name, "Capture Script Dry-Run");
+}
+
+#[test]
+fn test_doctor_report_rendering_all_pass() {
+    let checks = vec![
+        CheckResult::new("Zsh Executable", CheckStatus::Pass, "zsh 5.9"),
+        CheckResult::new("Zpty Module", CheckStatus::Pass, "module loaded"),
+    ];
+    let report = DoctorReport::new(checks);
+    assert!(report.is_all_passed());
+    assert_eq!(report.pass_count(), 2);
+    assert_eq!(report.fail_count(), 0);
+    assert_eq!(report.warn_count(), 0);
+
+    let mut output = Vec::new();
+    report.render(&mut output).unwrap();
+    let rendered = String::from_utf8(output).unwrap();
+
+    assert!(rendered.contains("[✓] Zsh Executable: zsh 5.9"));
+    assert!(rendered.contains("[✓] Zpty Module: module loaded"));
+    assert!(rendered.contains("Result: 2/2 checks passed"));
+}
+
+#[test]
+fn test_doctor_report_rendering_with_failures_and_warnings() {
+    let checks = vec![
+        CheckResult::new("Zsh Executable", CheckStatus::Pass, "zsh 5.9"),
+        CheckResult::new("Zpty Module", CheckStatus::Fail, "module not found"),
+        CheckResult::new("Custom Check", CheckStatus::Warn, "deprecated config"),
+    ];
+    let report = DoctorReport::new(checks);
+    assert!(!report.is_all_passed());
+    assert_eq!(report.pass_count(), 1);
+    assert_eq!(report.fail_count(), 1);
+    assert_eq!(report.warn_count(), 1);
+
+    let mut output = Vec::new();
+    report.render(&mut output).unwrap();
+    let rendered = String::from_utf8(output).unwrap();
+
+    assert!(rendered.contains("[✓] Zsh Executable: zsh 5.9"));
+    assert!(rendered.contains("[✗] Zpty Module: module not found"));
+    assert!(rendered.contains("[!] Custom Check: deprecated config"));
+    assert!(rendered.contains("Result: 1/3 checks passed, 1 failed"));
+}
+
+#[test]
+fn test_check_status_symbols_and_labels() {
+    assert_eq!(CheckStatus::Pass.symbol(), "[✓]");
+    assert_eq!(CheckStatus::Pass.label(), "PASS");
+
+    assert_eq!(CheckStatus::Warn.symbol(), "[!]");
+    assert_eq!(CheckStatus::Warn.label(), "WARN");
+
+    assert_eq!(CheckStatus::Fail.symbol(), "[✗]");
+    assert_eq!(CheckStatus::Fail.label(), "FAIL");
+}
+
+#[test]
+fn test_run_doctor_checks_returns_five_checks() {
+    let report = run_doctor_checks();
+    assert_eq!(report.checks.len(), 5);
+    assert_eq!(report.checks[0].name, "Zsh Executable");
+    assert_eq!(report.checks[1].name, "Zpty Module");
+    assert_eq!(report.checks[2].name, "Zutil Module");
+    assert_eq!(report.checks[3].name, "Cache Directory");
+    assert_eq!(report.checks[4].name, "Capture Script Dry-Run");
+    assert!(report.is_all_passed());
+}
+
+#[test]
+fn test_run_doctor_with_writer_writes_and_returns_true() {
+    let mut buffer = Vec::new();
+    let success = run_doctor_with_writer(&mut buffer);
+    assert!(success);
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert!(output.contains("zshcs doctor - Environment Health Check"));
+    assert!(output.contains("5/5 checks passed"));
+}
+
+#[test]
+fn test_run_doctor_function_returns_zero_exit_code() {
+    let code = run_doctor();
+    assert_eq!(code, 0);
+}


### PR DESCRIPTION
## Summary

This PR completes the DevEx milestones of **Phase 4** by introducing the `zshcs doctor` diagnostic subcommand:
1. **System Health Verification (`src/doctor.rs` & `run_doctor()`)**:
   - **Zsh Executable**: Checks for the existence, path, and version of `zsh`.
   - **Zpty Module**: Verifies whether `zsh/zpty` is loadable in the host Zsh environment.
   - **Zutil Module**: Verifies whether `zsh/zutil` is loadable for option parsing.
   - **Cache Directory**: Verifies creation and write permissions for `` / `/Users/yuys13/.cache/zshcs/zsh`.
   - **Capture Script Dry-Run**: Performs an interactive pty completion dry-run using the embedded `capture.zsh`.
2. **CLI Integration (`src/cli.rs` & `src/main.rs`)**:
   - Dispatches `zshcs doctor` via clap subcommands.
   - Returns exit code `0` when all checks pass and exit code `1` when critical checks fail.
3. **Architecture Documentation & Comprehensive Tests**:
   - Synchronizes `docs/ARCHITECTURE.md` with the Doctor Subsystem.
   - Adds `tests/doctor_test.rs` covering all health check scenarios, exit codes, and fallback behaviors.

## Changes

- **`src/doctor.rs`**:
  - Implement diagnostic check functions, formatted outputs, and dry-run verification.
- **`src/cli.rs`**:
  - Add `Commands::Doctor` subcommand.
- **`src/lib.rs` & `src/main.rs`**:
  - Export `doctor` module and dispatch subcommand execution.
- **`docs/ARCHITECTURE.md`**:
  - Document `zshcs doctor` in Section 2.1 and add Section 2.7 (Diagnostic Subsystem).
- **`tests/doctor_test.rs`**:
  - Add comprehensive unit and integration tests.

## Verification

All checks passed:
- `nix fmt` -> OK
- `cargo fmt --check` -> OK
- `cargo clippy --no-deps --all-targets -- -D warnings` -> OK (0 warnings)
- `cargo test --all-targets` -> OK (All 436 tests passed)
- `zsh tests/zsh/run_tests.zsh` -> OK (All 12 tests passed)