### PR TITLE
perf(ci): parallelize nix develop checks and nix build

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,13 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
       - name: Format Check
         run: nix fmt -- --ci
       - name: Flake Check
         run: nix flake check --no-build --all-systems --keep-going
-  build:
+  dev-shell:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
@@ -25,8 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
       - name: Cache dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -37,17 +33,27 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - name: Clippy
-        run: nix develop --command cargo clippy --no-deps --all-targets -- -D warnings
-      - name: Build
-        run: nix develop --command cargo build --release
-      - name: Run tests
-        run: nix develop --command cargo test
+      - name: Check devShell (Clippy, Build, Test)
+        run: |
+          nix develop --command bash -c "
+            set -euo pipefail
+            cargo clippy --no-deps --all-targets -- -D warnings
+            cargo build --release
+            cargo test
+          "
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
       - name: Nix Build
         run: nix build
   nix-all-checks:
     if: always()
-    needs: [flake-check, build]
+    needs: [flake-check, dev-shell, build]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all Nix CI checks passed


### PR DESCRIPTION
## Overview

Split the `nix develop` verification and `nix build` steps into separate parallel jobs in the Nix CI workflow (`nix.yml`) to speed up overall execution time.

## Key Changes

1. **Split `dev-shell` and `build` into parallel jobs**
   - Run `dev-shell` checks (Clippy, Release Build, Test) and `build` (`nix build`) concurrently on each matrix runner.
2. **Remove unused `nix_path`**
   - Removed `nix_path: nixpkgs=channel:nixos-unstable` as dependencies are locked via `flake.lock`, eliminating unnecessary channel downloads.
3. **Remove unnecessary Cargo cache in `nix build`**
   - Removed `actions/cache` step from `nix build` since sandbox builds do not utilize host Cargo caches.
4. **Consolidate `nix develop --command` calls**
   - Combined multiple `nix develop --command` invocations into a single subshell execution to reduce devShell initialization overhead.
5. **Update `nix-all-checks` aggregation**
   - Updated `needs: [flake-check, dev-shell, build]` to ensure all parallel jobs are tracked.