### PR TITLE
feat: implement experimental textDocument/documentSymbol with settings opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ return {
   cmd = { "zshcs" },
   filetypes = { "zsh" },
   root_markers = { ".git" },
-  -- Optional: Enable experimental features (definition, diagnostics, hover)
+  -- Optional: Enable experimental features (definition, diagnostics, hover, symbols)
   settings = {
     zshcs = {
       experimental = {
         definition = true,
         diagnostics = true,
         hover = true,
+        symbols = true,
       },
     },
   },
@@ -75,6 +76,7 @@ vim.lsp.enable("zshcs")
 - **Definition Provider (`textDocument/definition`)**: By default, definition jumping is disabled. You can opt-in by configuring `settings.zshcs.experimental.definition = true` in your LSP client configuration or `initializationOptions`. It resolves definitions for shell functions (`func() { ... }`, `function func { ... }`), shell variable declarations and assignments (`VAR=...`, `export VAR=...`, `typeset -g VAR=...`, `local VAR=...`), and external script file references (`source <path>`, `. <path>`).
 - **Syntax Diagnostics (`zsh -n`)**: By default, diagnostics are disabled to avoid unnecessary process overhead. You can opt-in by configuring `settings.zshcs.experimental.diagnostics = true` in your LSP client configuration or `initializationOptions`.
 - **Hover Documentation (`textDocument/hover`)**: By default, hover documentation is disabled. You can opt-in by configuring `settings.zshcs.experimental.hover = true` in your LSP client configuration or `initializationOptions`. It provides structured Markdown documentation for Zsh builtins and reserved words, and automatically falls back to full manual pages (`man`) formatted in code blocks for external commands (with 5000ms timeout protection).
+- **Document Symbol Provider (`textDocument/documentSymbol`)**: By default, document symbol extraction is disabled. You can opt-in by configuring `settings.zshcs.experimental.symbols = true` in your LSP client configuration or `initializationOptions`. It extracts shell functions (`SymbolKind::FUNCTION`), variable declarations and assignments (`SymbolKind::VARIABLE`), and aliases (`SymbolKind::OPERATOR`) in a hierarchical structure.
 
 
 ## How It Works

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,11 +16,12 @@ flowchart TB
 
     subgraph RustServer [Rust LSP Server Process (zshcs)]
         LSPBackend["LSP Backend (`src/server.rs`)<br/>• LanguageServer Trait<br/>• Request Routing & Commands"]
-        ConfigMgr["Config Subsystem (`src/config.rs`)<br/>• Opt-In Schema Parsing<br/>• Experimental Diagnostics, Hover & Definition Flags"]
+        ConfigMgr["Config Subsystem (`src/config.rs`)<br/>• Opt-In Schema Parsing<br/>• Experimental Diagnostics, Hover, Definition & Symbols Flags"]
         DocMgr["DocumentManager (`src/document.rs`)<br/>• In-Memory Arc&lt;DashMap&lt;Url, DocumentState&gt;&gt;<br/>• Incremental Sync & UTF-16/UTF-8 Mapping"]
         DiagEngine["Diagnostics Engine (`src/diagnostics.rs`)<br/>• Non-blocking `zsh -n` Runner<br/>• Debounced Stderr Parser"]
         HoverEngine["Hover Engine (`src/hover.rs`)<br/>• Word Extraction & Range Mapping<br/>• Builtin & Reserved Words Dictionary<br/>• Async manpage Full-Text Retrieval"]
         DefinitionEngine["Definition Engine (`src/definition.rs`)<br/>• Function, Variable & Source Resolvers<br/>• UTF-16 Code Unit Location Mapping"]
+        SymbolsEngine["Document Symbol Engine (`src/symbols.rs`)<br/>• Function, Variable & Alias Extraction<br/>• Hierarchical Symbol Tree & UTF-16 Bounds"]
         Supervisor["Daemon Supervisor (`src/completion.rs`)<br/>• run_completion_daemon<br/>• HoL Cancellation & Timeout Guard<br/>• Process Recovery & chdir Sync"]
         Logging["Logging Subsystem (`src/logging.rs`)<br/>• tracing & tracing-subscriber<br/>• Stderr Destination & EnvFilter"]
         ErrHandling["Error Hierarchy (`src/error.rs`)<br/>• ZshcsError / ZshcsResult<br/>• Type-Safe Conversions"]
@@ -38,6 +39,7 @@ flowchart TB
     DiagEngine -.->|publishDiagnostics| Editor
     LSPBackend -->|Cursor Word Hover Query| HoverEngine
     LSPBackend -->|Definition Jump Query| DefinitionEngine
+    LSPBackend -->|Document Symbol Outline Query| SymbolsEngine
     LSPBackend -->|mpsc / oneshot| Supervisor
     RustServer -.->|Structured Logs (stderr)| Editor
     Supervisor <-->|Piped stdin/stdout (RPC: input / chdir)| CaptureScript
@@ -60,6 +62,7 @@ The entry point and server backend coordinate command-line argument parsing, LSP
   - **Text Document Sync**: `TextDocumentSyncKind::INCREMENTAL` for fine-grained, low-latency diff synchronization.
   - **Hover Provider**: `HoverProviderCapability::Simple(true)` providing on-demand documentation lookups.
   - **Definition Provider**: `Some(OneOf::Left(true))` providing opt-in `textDocument/definition` navigation.
+  - **Document Symbol Provider**: `Some(OneOf::Left(true))` providing opt-in `textDocument/documentSymbol` outline generation.
   - **Trigger Characters**: Registers `["-", "$", "/", "~", ".", " "]` to trigger completions immediately upon typing flags, variables, directory paths, hidden files, or subcommands.
   - **Execute Command Provider**: Exposes custom command `zshcs/getDocumentContent` for internal document state inspection and integration testing.
 - **Dual Initialization Pathways**:
@@ -418,6 +421,44 @@ flowchart TD
 
 ---
 
+### 2.12 Experimental Document Symbol Subsystem (`src/symbols.rs`, `src/config.rs`)
+
+`zshcs` provides an opt-in, zero-overhead document symbol engine (`textDocument/documentSymbol`) extracting shell functions, variable and constant declarations, and alias definitions into an editor-navigable hierarchical symbol tree.
+
+- **Experimental Opt-In Configuration (`src/config.rs`)**:
+  - Disabled by default (`symbols: false`) to ensure zero scanning and AST overhead for standard completion-only setups.
+  - Dynamically configured via LSP `initializationOptions` (startup) or `workspace/didChangeConfiguration` (runtime) using the schema:
+    ```json
+    {
+      "zshcs": {
+        "experimental": {
+          "symbols": true
+        }
+      }
+    }
+    ```
+  - Also accepts flat `{ "experimental": { "symbols": true } }` payloads.
+- **Three-Tier Symbol Extraction (`extract_document_symbols`)**:
+  1. **Shell Function Extraction (`SymbolKind::FUNCTION`)**:
+     - Scans for POSIX syntax (`func() { ... }`, `func () { ... }`) and keyword syntax (`function func { ... }`, `function func() { ... }`).
+     - Accurately tracks nested braces (`{ ... }`), string literals (`"..."`, `'...'`, `` `...` ``), escape characters, and comments to compute the full function range from start statement to matching closing `}`.
+     - Sets `selection_range` pointing to the exact function identifier.
+  2. **Variable & Constant Declaration Extraction (`SymbolKind::VARIABLE`)**:
+     - Captures keyword declarations: `export`, `typeset` (including `-g` global and `-a` array), `local`, `declare`, `readonly`, `integer`, and `float`.
+     - Captures direct assignments: `VAR=...`, `VAR+=...`, `VAR[k]=...`, and array assignments `VAR=(...)`.
+     - Sets `selection_range` to the variable name and `range` to the declaration/assignment token.
+  3. **Alias Definition Extraction (`SymbolKind::OPERATOR`)**:
+     - Captures standard aliases (`alias name='...'`), global aliases (`alias -g name='...'`), suffix aliases (`alias -s name=...`), and multi-alias declarations on single lines.
+     - Sets `selection_range` to the alias identifier name and `detail` to the alias expansion target.
+- **Hierarchical Tree Construction (`build_symbol_tree`)**:
+  - Employs a stack-based algorithm sorting symbols by starting coordinates (with larger enclosing spans prioritized).
+  - Automatically nests local variables, inner aliases, and nested functions inside their enclosing function's `children` array while maintaining top-level symbols in document order.
+- **Robustness & UTF-16 Multi-Byte Safety**:
+  - Converts all line/column positions to LSP UTF-16 code units via `byte_to_utf16_col`, correctly handling multi-byte CJK ideographs, surrogate pairs, and emoji sequences.
+  - Tolerates unclosed braces, syntax errors, and malformed statements gracefully without panic.
+
+---
+
 ## 3. Detailed Data Flow & Protocols
 
 ### 3.1 Completion Request Lifecycle
@@ -579,6 +620,37 @@ sequenceDiagram
 
 ---
 
+### 3.5 Experimental Document Symbol Request Lifecycle
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User as Editor User
+    participant Client as LSP Client
+    participant Server as Backend (`src/server.rs`)
+    participant DocMgr as DocumentManager (`src/document.rs`)
+    participant Sym as Document Symbol Engine (`src/symbols.rs`)
+
+    User->>Client: Open file / Request document symbols (outline tree)
+    Client->>Server: textDocument/documentSymbol (uri)
+    alt Experimental Symbols Disabled (default)
+        Server-->>Client: Ok(None) (Zero overhead)
+    else Experimental Symbols Enabled
+        Server->>DocMgr: get_content(uri)
+        DocMgr-->>Server: Some(doc_text)
+        Server->>Sym: extract_document_symbols(doc_text, uri)
+        Sym->>Sym: Scan functions (POSIX & keyword style)
+        Sym->>Sym: Scan variable declarations & assignments
+        Sym->>Sym: Scan alias definitions
+        Sym->>Sym: build_symbol_tree (hierarchical nesting)
+        Sym-->>Server: Vec<DocumentSymbol>
+        Server-->>Client: Ok(Some(DocumentSymbolResponse::Nested(symbols)))
+        Client-->>User: Render document outline tree / breadcrumbs
+    end
+```
+
+---
+
 ## 4. Testing, QA & Quality Gates
 
 `zshcs` enforces quality assurance through a multi-tier testing and verification architecture:
@@ -610,6 +682,7 @@ flowchart LR
 ### 4.1 Test Suites Overview
 
 1. **Rust Integration & Unit Test Suites**:
+   - `tests/symbols_test.rs` (7 tests): Validates experimental document symbol provider opt-in via `initializationOptions`, dynamic toggling via `workspace/didChangeConfiguration`, function/variable/alias extraction, hierarchical nesting of local variables and inner functions, flat/nested settings schema compatibility, and unopened document handling.
    - `tests/definition_test.rs` (10 tests): Validates experimental definition provider opt-in via `initializationOptions`, dynamic toggling via `workspace/didChangeConfiguration`, function definition jumping, external script source jumping (`source` / `.`), compound source statements, variable declaration/assignment/loop/read variable jumping, multi-statement lines, nested parameter expansions with flags, and edge case handling (unopened buffers, comments, whitespace, nonexistent targets).
    - `tests/hover_test.rs` (8 tests): Validates experimental hover documentation opt-in via `initializationOptions`, dynamic toggling via `workspace/didChangeConfiguration`, builtin/reserved word markdown rendering, external command `man` page retrieval in code blocks, and whitespace/out-of-bounds cursor handling.
    - `tests/diagnostics_test.rs` (9 tests): Validates experimental syntax diagnostics opt-in via `initializationOptions`, dynamic toggling via `workspace/didChangeConfiguration`, syntax error reporting, error clearing on fix, buffer closing cleanup, and edit debouncing.

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,13 +21,16 @@ pub struct ExperimentalConfig {
     /// Whether experimental definition provider is enabled.
     #[serde(default)]
     pub definition: bool,
+    /// Whether experimental document symbol provider is enabled.
+    #[serde(default)]
+    pub symbols: bool,
 }
 
 impl Config {
     /// Parses configuration from an optional JSON value (e.g. `initializationOptions` or `settings`).
     ///
     /// Looks for `["zshcs"]["experimental"]["diagnostics"]`, `["zshcs"]["experimental"]["hover"]`,
-    /// and `["zshcs"]["experimental"]["definition"]` first,
+    /// `["zshcs"]["experimental"]["definition"]`, and `["zshcs"]["experimental"]["symbols"]` first,
     /// then `["settings"]["zshcs"]...`, and falls back to `["experimental"]...` if present.
     /// Defaults to `false` for experimental features.
     pub fn from_value(value: Option<&Value>) -> Self {
@@ -39,7 +42,7 @@ impl Config {
             return Self::default();
         }
 
-        // 1. Try parsing from `zshcs` key: {"zshcs": {"experimental": {"diagnostics": true, "hover": true, "definition": true}}}
+        // 1. Try parsing from `zshcs` key: {"zshcs": {"experimental": {"diagnostics": true, "hover": true, "definition": true, "symbols": true}}}
         if let Some(zshcs_val) = val.get("zshcs")
             && let Ok(config) = serde_json::from_value::<Config>(zshcs_val.clone())
         {
@@ -51,7 +54,7 @@ impl Config {
             return Self::from_value(Some(settings_val));
         }
 
-        // 3. Try parsing root object directly: {"experimental": {"diagnostics": true, "hover": true, "definition": true}}
+        // 3. Try parsing root object directly: {"experimental": {"diagnostics": true, "hover": true, "definition": true, "symbols": true}}
         if let Ok(config) = serde_json::from_value::<Config>(val.clone()) {
             return config;
         }
@@ -73,6 +76,11 @@ impl Config {
     pub fn experimental_definition(&self) -> bool {
         self.experimental.definition
     }
+
+    /// Returns true if experimental symbols is enabled.
+    pub fn experimental_symbols(&self) -> bool {
+        self.experimental.symbols
+    }
 }
 
 /// Extracts whether experimental diagnostics is enabled from an optional JSON value.
@@ -90,6 +98,11 @@ pub fn extract_experimental_definition(value: Option<&Value>) -> bool {
     Config::from_value(value).experimental_definition()
 }
 
+/// Extracts whether experimental symbols is enabled from an optional JSON value.
+pub fn extract_experimental_symbols(value: Option<&Value>) -> bool {
+    Config::from_value(value).experimental_symbols()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -104,6 +117,8 @@ mod tests {
         assert!(!config.experimental_hover());
         assert!(!config.experimental.definition);
         assert!(!config.experimental_definition());
+        assert!(!config.experimental.symbols);
+        assert!(!config.experimental_symbols());
     }
 
     #[test]
@@ -250,12 +265,13 @@ mod tests {
                 diagnostics: true,
                 hover: true,
                 definition: true,
+                symbols: true,
             },
         };
         let val = serde_json::to_value(&config).unwrap();
         assert_eq!(
             val,
-            json!({ "experimental": { "diagnostics": true, "hover": true, "definition": true } })
+            json!({ "experimental": { "diagnostics": true, "hover": true, "definition": true, "symbols": true } })
         );
 
         let deserialized = Config::from_value(Some(&val));
@@ -464,5 +480,107 @@ mod tests {
             }
         });
         assert!(!extract_experimental_definition(Some(&val3)));
+    }
+
+    #[test]
+    fn test_extract_symbols_none_and_null() {
+        assert!(!extract_experimental_symbols(None));
+        let val_null = json!(null);
+        assert!(!extract_experimental_symbols(Some(&val_null)));
+        let val_empty = json!({});
+        assert!(!extract_experimental_symbols(Some(&val_empty)));
+    }
+
+    #[test]
+    fn test_extract_symbols_nested_zshcs() {
+        let val = json!({
+            "zshcs": {
+                "experimental": {
+                    "symbols": true
+                }
+            }
+        });
+        let config = Config::from_value(Some(&val));
+        assert!(config.experimental_symbols());
+        assert!(extract_experimental_symbols(Some(&val)));
+
+        let val_false = json!({
+            "zshcs": {
+                "experimental": {
+                    "symbols": false
+                }
+            }
+        });
+        let config_false = Config::from_value(Some(&val_false));
+        assert!(!config_false.experimental_symbols());
+        assert!(!extract_experimental_symbols(Some(&val_false)));
+    }
+
+    #[test]
+    fn test_extract_symbols_direct_experimental() {
+        let val = json!({
+            "experimental": {
+                "symbols": true
+            }
+        });
+        let config = Config::from_value(Some(&val));
+        assert!(config.experimental_symbols());
+        assert!(extract_experimental_symbols(Some(&val)));
+
+        let val_false = json!({
+            "experimental": {
+                "symbols": false
+            }
+        });
+        let config_false = Config::from_value(Some(&val_false));
+        assert!(!config_false.experimental_symbols());
+        assert!(!extract_experimental_symbols(Some(&val_false)));
+    }
+
+    #[test]
+    fn test_extract_symbols_nested_settings_wrapper() {
+        let val = json!({
+            "settings": {
+                "zshcs": {
+                    "experimental": {
+                        "symbols": true
+                    }
+                }
+            }
+        });
+        let config = Config::from_value(Some(&val));
+        assert!(config.experimental_symbols());
+        assert!(extract_experimental_symbols(Some(&val)));
+
+        let val_false = json!({
+            "settings": {
+                "zshcs": {
+                    "experimental": {
+                        "symbols": false
+                    }
+                }
+            }
+        });
+        let config_false = Config::from_value(Some(&val_false));
+        assert!(!config_false.experimental_symbols());
+        assert!(!extract_experimental_symbols(Some(&val_false)));
+    }
+
+    #[test]
+    fn test_extract_symbols_invalid_types() {
+        let val1 = json!("invalid string");
+        assert!(!extract_experimental_symbols(Some(&val1)));
+
+        let val2 = json!(456);
+        assert!(!extract_experimental_symbols(Some(&val2)));
+
+        let val3 = json!({
+            "zshcs": {
+                "experimental": {
+                    "symbols": "not a boolean"
+                }
+            }
+        });
+        assert!(!extract_experimental_symbols(Some(&val3)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,13 @@ pub mod error;
 pub mod hover;
 pub mod logging;
 pub mod server;
+pub mod symbols;
 
 pub use cli::{Cli, Commands};
 pub use completion::{CAPTURE_ZSH, ZPTYRC_ZSH, infer_completion_kind};
 pub use config::{
     Config, ExperimentalConfig, extract_experimental_definition, extract_experimental_diagnostics,
-    extract_experimental_hover,
+    extract_experimental_hover, extract_experimental_symbols,
 };
 pub use definition::{
     DeclarationToken, DefinitionTarget, StatementSpan, byte_to_utf16_col,
@@ -41,3 +42,4 @@ pub use hover::{
 };
 pub use logging::{create_env_filter, init_logging, try_init_logging};
 pub use server::Backend;
+pub use symbols::extract_document_symbols;

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,6 +17,7 @@ use crate::diagnostics::check_syntax;
 use crate::document::DocumentManager;
 use crate::error::{ZshcsError, ZshcsResult};
 use crate::hover::{extract_word_at_position, get_hover_info};
+use crate::symbols::extract_document_symbols;
 
 #[derive(Debug)]
 pub struct Backend {
@@ -141,6 +142,10 @@ impl Backend {
     pub async fn is_definition_enabled(&self) -> bool {
         self.config.read().await.experimental_definition()
     }
+
+    pub async fn is_symbols_enabled(&self) -> bool {
+        self.config.read().await.experimental_symbols()
+    }
 }
 
 #[tower_lsp::async_trait]
@@ -160,6 +165,7 @@ impl LanguageServer for Backend {
                 experimental_diagnostics = initial_config.experimental_diagnostics(),
                 experimental_hover = initial_config.experimental_hover(),
                 experimental_definition = initial_config.experimental_definition(),
+                experimental_symbols = initial_config.experimental_symbols(),
                 "Parsed initial server configuration"
             );
             *self.config.write().await = initial_config;
@@ -176,6 +182,7 @@ impl LanguageServer for Backend {
                 )),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
                 definition_provider: Some(OneOf::Left(true)),
+                document_symbol_provider: Some(OneOf::Left(true)),
                 completion_provider: Some(CompletionOptions {
                     resolve_provider: Some(false),
                     trigger_characters: Some(vec![
@@ -580,6 +587,38 @@ impl LanguageServer for Backend {
             "Goto definition result resolved"
         );
         Ok(response)
+    }
+
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> Result<Option<DocumentSymbolResponse>> {
+        if !self.is_symbols_enabled().await {
+            tracing::debug!("Document symbol requested but experimental symbols is disabled");
+            return Ok(None);
+        }
+
+        let uri = params.text_document.uri;
+        tracing::debug!(uri = %uri, "Document symbol request received");
+
+        let doc_text = match self.document_manager.get_content(&uri) {
+            Some(t) => t,
+            None => {
+                tracing::debug!(
+                    uri = %uri,
+                    "Document not found in document_manager for document_symbol"
+                );
+                return Ok(None);
+            }
+        };
+
+        let symbols = extract_document_symbols(&doc_text, &uri);
+        tracing::debug!(
+            uri = %uri,
+            count = symbols.len(),
+            "Document symbols extracted successfully"
+        );
+        Ok(Some(DocumentSymbolResponse::Nested(symbols)))
     }
 
     async fn execute_command(&self, params: ExecuteCommandParams) -> Result<Option<Value>> {

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1,0 +1,1016 @@
+use tower_lsp::lsp_types::{DocumentSymbol, Position, Range, SymbolKind, Url};
+
+use crate::definition::{
+    byte_to_utf16_col, is_func_ident_char, is_var_ident_char, split_declaration_tokens,
+    split_line_statements,
+};
+
+/// Keywords that should not be treated as function names or variable assignments.
+const RESERVED_KEYWORDS: &[&str] = &[
+    "if",
+    "then",
+    "elif",
+    "else",
+    "fi",
+    "for",
+    "while",
+    "until",
+    "do",
+    "done",
+    "case",
+    "esac",
+    "select",
+    "time",
+    "repeat",
+    "nocorrect",
+    "coproc",
+    "return",
+    "exit",
+    "local",
+    "export",
+    "typeset",
+    "declare",
+    "readonly",
+    "integer",
+    "float",
+    "alias",
+    "echo",
+    "read",
+    "source",
+    "set",
+    "shift",
+    "test",
+    "trap",
+    "unset",
+    "function",
+];
+
+/// Checks if a word is a reserved shell keyword.
+fn is_reserved_keyword(word: &str) -> bool {
+    RESERVED_KEYWORDS.contains(&word)
+}
+
+/// Skips flags (e.g. `-T`, `-u`, `+x`) in a string and returns the remaining slice.
+fn skip_flags(input: &str) -> &str {
+    let mut rest = input.trim_start();
+    while rest.starts_with('-') || rest.starts_with('+') {
+        let flag_len = rest
+            .find(|c: char| c.is_ascii_whitespace())
+            .unwrap_or(rest.len());
+        rest = rest[flag_len..].trim_start();
+    }
+    rest
+}
+
+/// Finds the closing `}` matching the opening `{` starting at `(open_line, open_byte_col)`.
+fn find_matching_closing_brace(
+    lines: &[&str],
+    open_line: usize,
+    open_byte_col: usize,
+) -> (usize, u32) {
+    let mut depth: usize = 0;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut in_backtick = false;
+
+    for (line_idx, line) in lines.iter().enumerate().skip(open_line) {
+        let bytes = line.as_bytes();
+        let len = bytes.len();
+        let start_col = if line_idx == open_line {
+            open_byte_col
+        } else {
+            0
+        };
+
+        let mut i = start_col;
+        while i < len {
+            let b = bytes[i];
+
+            if b == b'\\' && !in_single_quote && i + 1 < len {
+                i += 2;
+                continue;
+            }
+
+            if in_single_quote {
+                if b == b'\'' {
+                    in_single_quote = false;
+                }
+            } else if in_double_quote {
+                if b == b'"' {
+                    in_double_quote = false;
+                }
+            } else if in_backtick {
+                if b == b'`' {
+                    in_backtick = false;
+                }
+            } else {
+                match b {
+                    b'\'' => in_single_quote = true,
+                    b'"' => in_double_quote = true,
+                    b'`' => in_backtick = true,
+                    b'#' => {
+                        // Comment starts; skip rest of line
+                        break;
+                    }
+                    b'{' => {
+                        depth += 1;
+                    }
+                    b'}' if depth > 0 => {
+                        depth -= 1;
+                        if depth == 0 {
+                            let end_u16 = byte_to_utf16_col(line, i + 1);
+                            return (line_idx, end_u16);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            i += 1;
+        }
+    }
+
+    // If unclosed, return end of last line
+    let last_line_idx = lines.len().saturating_sub(1);
+    let last_line = lines.get(last_line_idx).copied().unwrap_or("");
+    let end_u16 = byte_to_utf16_col(last_line, last_line.len());
+    (last_line_idx, end_u16)
+}
+
+/// Searches forward for the first opening `{` starting from `start_line` and `start_byte_col`.
+fn find_opening_brace(
+    lines: &[&str],
+    start_line: usize,
+    start_byte_col: usize,
+) -> Option<(usize, usize)> {
+    for (line_idx, line) in lines.iter().enumerate().skip(start_line) {
+        let bytes = line.as_bytes();
+        let len = bytes.len();
+        let col = if line_idx == start_line {
+            start_byte_col
+        } else {
+            0
+        };
+
+        let mut in_single_quote = false;
+        let mut in_double_quote = false;
+        let mut in_backtick = false;
+
+        let mut i = col;
+        while i < len {
+            let b = bytes[i];
+
+            if b == b'\\' && !in_single_quote && i + 1 < len {
+                i += 2;
+                continue;
+            }
+
+            if in_single_quote {
+                if b == b'\'' {
+                    in_single_quote = false;
+                }
+            } else if in_double_quote {
+                if b == b'"' {
+                    in_double_quote = false;
+                }
+            } else if in_backtick {
+                if b == b'`' {
+                    in_backtick = false;
+                }
+            } else if b == b'#' {
+                break;
+            } else if b == b'{' {
+                return Some((line_idx, i));
+            } else if b == b';' && line_idx == start_line {
+                // If statement terminates before `{`, check if next tokens or next line has `{`
+            }
+            i += 1;
+        }
+
+        // If we crossed beyond the start line and encountered non-empty non-comment code without `{`, stop searching
+        if line_idx > start_line {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() && !trimmed.starts_with('#') && !trimmed.starts_with('{') {
+                break;
+            }
+        }
+    }
+
+    None
+}
+
+/// Checks if a parent range strictly contains a child range.
+fn range_contains(parent: &Range, child: &Range) -> bool {
+    let start_ok = (parent.start.line < child.start.line)
+        || (parent.start.line == child.start.line
+            && parent.start.character <= child.start.character);
+    let end_ok = (parent.end.line > child.end.line)
+        || (parent.end.line == child.end.line && parent.end.character >= child.end.character);
+    start_ok && end_ok
+}
+
+/// Builds a hierarchical `DocumentSymbol` tree from a flat list of extracted symbols.
+fn build_symbol_tree(mut symbols: Vec<DocumentSymbol>) -> Vec<DocumentSymbol> {
+    // Sort symbols:
+    // 1. By start line ascending
+    // 2. By start character ascending
+    // 3. By end line descending (enclosing symbols first)
+    // 4. By end character descending
+    symbols.sort_by(|a, b| {
+        let cmp_start_line = a.range.start.line.cmp(&b.range.start.line);
+        if cmp_start_line != std::cmp::Ordering::Equal {
+            return cmp_start_line;
+        }
+        let cmp_start_char = a.range.start.character.cmp(&b.range.start.character);
+        if cmp_start_char != std::cmp::Ordering::Equal {
+            return cmp_start_char;
+        }
+        let cmp_end_line = b.range.end.line.cmp(&a.range.end.line);
+        if cmp_end_line != std::cmp::Ordering::Equal {
+            return cmp_end_line;
+        }
+        b.range.end.character.cmp(&a.range.end.character)
+    });
+
+    let mut root: Vec<DocumentSymbol> = Vec::new();
+    let mut stack: Vec<DocumentSymbol> = Vec::new();
+
+    for sym in symbols {
+        while let Some(top) = stack.last() {
+            if top.kind == SymbolKind::FUNCTION && range_contains(&top.range, &sym.range) {
+                break;
+            }
+            let popped = stack.pop().unwrap();
+            if let Some(parent) = stack.last_mut() {
+                parent.children.get_or_insert_with(Vec::new).push(popped);
+            } else {
+                root.push(popped);
+            }
+        }
+        stack.push(sym);
+    }
+
+    while let Some(popped) = stack.pop() {
+        if let Some(parent) = stack.last_mut() {
+            parent.children.get_or_insert_with(Vec::new).push(popped);
+        } else {
+            root.push(popped);
+        }
+    }
+
+    root
+}
+
+/// Extracts document symbols (functions, variables, aliases) in a hierarchical tree.
+pub fn extract_document_symbols(text: &str, _uri: &Url) -> Vec<DocumentSymbol> {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut raw_symbols = Vec::new();
+
+    let decl_keywords = [
+        "export", "typeset", "local", "declare", "readonly", "integer", "float",
+    ];
+
+    for (line_idx, line) in lines.iter().enumerate() {
+        for stmt in split_line_statements(line) {
+            let trimmed = stmt.text.trim_start();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+
+            let stmt_indent = stmt.text.len() - trimmed.len();
+            let stmt_offset = stmt.start_byte + stmt_indent;
+
+            // 1. Check for Shell Functions
+            let mut detected_function: Option<(String, Range, Range)> = None;
+
+            // 1.1 Keyword style: `function func ...` or `function func() ...`
+            if trimmed.starts_with("function ")
+                || trimmed.starts_with("function\t")
+                || trimmed == "function"
+            {
+                let after_kw = if trimmed.len() > 8 { &trimmed[8..] } else { "" };
+                let after_kw_trimmed = after_kw.trim_start();
+                let kw_spaces = after_kw.len() - after_kw_trimmed.len();
+                let rest = skip_flags(after_kw_trimmed);
+                let flag_len = after_kw_trimmed.len() - rest.len();
+
+                let name: String = rest
+                    .chars()
+                    .take_while(|c| is_func_ident_char(*c) && *c != '(' && *c != '{')
+                    .collect();
+
+                if !name.is_empty() && !is_reserved_keyword(&name) {
+                    let after_name = &rest[name.len()..].trim_start();
+                    let after_parens = if let Some(stripped) = after_name.strip_prefix("()") {
+                        stripped.trim_start()
+                    } else if after_name.starts_with('(')
+                        && let Some(close) = after_name.find(')')
+                    {
+                        after_name[close + 1..].trim_start()
+                    } else {
+                        after_name
+                    };
+
+                    if after_parens.is_empty()
+                        || after_parens.starts_with('{')
+                        || after_parens.starts_with(';')
+                        || after_parens.starts_with('#')
+                    {
+                        let name_start_byte = stmt_offset + 8 + kw_spaces + flag_len;
+                        let name_end_byte = name_start_byte + name.len();
+                        let sel_start_u16 = byte_to_utf16_col(line, name_start_byte);
+                        let sel_end_u16 = byte_to_utf16_col(line, name_end_byte);
+                        let sel_range = Range::new(
+                            Position::new(line_idx as u32, sel_start_u16),
+                            Position::new(line_idx as u32, sel_end_u16),
+                        );
+
+                        // Find opening brace and matching closing brace
+                        let func_start_u16 = byte_to_utf16_col(line, stmt_offset);
+                        let search_start_byte = name_end_byte;
+                        let (end_line, end_u16) = if let Some((open_line, open_byte)) =
+                            find_opening_brace(&lines, line_idx, search_start_byte)
+                        {
+                            find_matching_closing_brace(&lines, open_line, open_byte)
+                        } else {
+                            (
+                                line_idx,
+                                byte_to_utf16_col(line, stmt.start_byte + stmt.text.len()),
+                            )
+                        };
+
+                        let full_range = Range::new(
+                            Position::new(line_idx as u32, func_start_u16),
+                            Position::new(end_line as u32, end_u16),
+                        );
+
+                        detected_function = Some((name, full_range, sel_range));
+                    }
+                }
+            }
+
+            // 1.2 POSIX style: `func() { ... }` or `func () { ... }`
+            if detected_function.is_none()
+                && let Some(open_paren_idx) = trimmed.find('(')
+            {
+                let name_part = trimmed[..open_paren_idx].trim_end();
+                if !name_part.is_empty()
+                    && !name_part.starts_with('#')
+                    && !name_part.chars().next().unwrap().is_ascii_digit()
+                    && name_part.chars().all(is_func_ident_char)
+                    && !is_reserved_keyword(name_part)
+                {
+                    let after_open = trimmed[open_paren_idx + 1..].trim_start();
+                    if let Some(stripped_close) = after_open.strip_prefix(')') {
+                        let after_parens = stripped_close.trim_start();
+                        if after_parens.is_empty()
+                            || after_parens.starts_with('{')
+                            || after_parens.starts_with(';')
+                            || after_parens.starts_with('#')
+                        {
+                            let name_start_byte =
+                                stmt_offset + trimmed.find(name_part).unwrap_or(0);
+                            let name_end_byte = name_start_byte + name_part.len();
+                            let sel_start_u16 = byte_to_utf16_col(line, name_start_byte);
+                            let sel_end_u16 = byte_to_utf16_col(line, name_end_byte);
+                            let sel_range = Range::new(
+                                Position::new(line_idx as u32, sel_start_u16),
+                                Position::new(line_idx as u32, sel_end_u16),
+                            );
+
+                            let func_start_u16 = byte_to_utf16_col(line, stmt_offset);
+                            let search_start_byte = name_end_byte;
+                            let (end_line, end_u16) = if let Some((open_line, open_byte)) =
+                                find_opening_brace(&lines, line_idx, search_start_byte)
+                            {
+                                find_matching_closing_brace(&lines, open_line, open_byte)
+                            } else {
+                                (
+                                    line_idx,
+                                    byte_to_utf16_col(line, stmt.start_byte + stmt.text.len()),
+                                )
+                            };
+
+                            let full_range = Range::new(
+                                Position::new(line_idx as u32, func_start_u16),
+                                Position::new(end_line as u32, end_u16),
+                            );
+
+                            detected_function =
+                                Some((name_part.to_string(), full_range, sel_range));
+                        }
+                    }
+                }
+            }
+
+            if let Some((name, range, selection_range)) = detected_function {
+                raw_symbols.push(DocumentSymbol {
+                    name,
+                    detail: Some("()".to_string()),
+                    kind: SymbolKind::FUNCTION,
+                    tags: None,
+                    #[allow(deprecated)]
+                    deprecated: None,
+                    range,
+                    selection_range,
+                    children: None,
+                });
+                continue;
+            }
+
+            // 2. Check for Alias Declarations: `alias ...`
+            if trimmed.starts_with("alias ") || trimmed.starts_with("alias\t") || trimmed == "alias"
+            {
+                let after_alias = if trimmed.len() > 5 { &trimmed[5..] } else { "" };
+                let alias_offset = stmt_offset + 5;
+
+                for token in split_declaration_tokens(after_alias) {
+                    if token.text.starts_with('-') || token.text.starts_with('+') {
+                        continue;
+                    }
+
+                    let token_str = token.text;
+                    let token_start_in_line = alias_offset + token.byte_offset;
+                    let (name_raw, val_opt) = if let Some(eq) = token_str.find('=') {
+                        (&token_str[..eq], Some(&token_str[eq + 1..]))
+                    } else {
+                        (token_str, None)
+                    };
+
+                    let alias_name = name_raw.trim();
+                    if !alias_name.is_empty()
+                        && alias_name
+                            .chars()
+                            .all(|c| is_func_ident_char(c) || c == '-')
+                        && !is_reserved_keyword(alias_name)
+                    {
+                        let name_start_byte =
+                            token_start_in_line + token_str.find(alias_name).unwrap_or(0);
+                        let name_end_byte = name_start_byte + alias_name.len();
+                        let sel_start_u16 = byte_to_utf16_col(line, name_start_byte);
+                        let sel_end_u16 = byte_to_utf16_col(line, name_end_byte);
+                        let selection_range = Range::new(
+                            Position::new(line_idx as u32, sel_start_u16),
+                            Position::new(line_idx as u32, sel_end_u16),
+                        );
+
+                        let tok_start_u16 = byte_to_utf16_col(line, token_start_in_line);
+                        let tok_end_u16 =
+                            byte_to_utf16_col(line, token_start_in_line + token_str.len());
+                        let range = Range::new(
+                            Position::new(line_idx as u32, tok_start_u16),
+                            Position::new(line_idx as u32, tok_end_u16),
+                        );
+
+                        let detail = val_opt
+                            .map(|v| v.trim_matches('\'').trim_matches('"').to_string())
+                            .or_else(|| Some("alias".to_string()));
+
+                        raw_symbols.push(DocumentSymbol {
+                            name: alias_name.to_string(),
+                            detail,
+                            kind: SymbolKind::OPERATOR,
+                            tags: None,
+                            #[allow(deprecated)]
+                            deprecated: None,
+                            range,
+                            selection_range,
+                            children: None,
+                        });
+                    }
+                }
+                continue;
+            }
+
+            // 3. Check for Keyword Variable Declarations: `local`, `export`, `typeset`, etc.
+            let mut matched_decl_kw = false;
+            for kw in decl_keywords {
+                if trimmed.starts_with(kw)
+                    && (trimmed[kw.len()..].starts_with(' ')
+                        || trimmed[kw.len()..].starts_with('\t')
+                        || trimmed.len() == kw.len())
+                {
+                    matched_decl_kw = true;
+                    let after_kw = &trimmed[kw.len()..];
+                    let kw_offset = stmt_offset + kw.len();
+
+                    for token in split_declaration_tokens(after_kw) {
+                        if token.text.starts_with('-') || token.text.starts_with('+') {
+                            continue;
+                        }
+
+                        let token_str = token.text;
+                        let token_start_in_line = kw_offset + token.byte_offset;
+
+                        let var_name_raw = if let Some(eq) = token_str.find('=') {
+                            let before_eq = &token_str[..eq];
+                            if let Some(stripped) = before_eq.strip_suffix('+') {
+                                stripped
+                            } else if let Some(br) = before_eq.find('[') {
+                                &before_eq[..br]
+                            } else {
+                                before_eq
+                            }
+                        } else if let Some(br) = token_str.find('[') {
+                            &token_str[..br]
+                        } else {
+                            token_str
+                        };
+
+                        let var_name = var_name_raw.trim();
+                        if !var_name.is_empty()
+                            && !var_name.chars().next().unwrap().is_ascii_digit()
+                            && var_name.chars().all(is_var_ident_char)
+                            && !is_reserved_keyword(var_name)
+                        {
+                            let name_start_byte =
+                                token_start_in_line + token_str.find(var_name).unwrap_or(0);
+                            let name_end_byte = name_start_byte + var_name.len();
+                            let sel_start_u16 = byte_to_utf16_col(line, name_start_byte);
+                            let sel_end_u16 = byte_to_utf16_col(line, name_end_byte);
+                            let selection_range = Range::new(
+                                Position::new(line_idx as u32, sel_start_u16),
+                                Position::new(line_idx as u32, sel_end_u16),
+                            );
+
+                            let tok_start_u16 = byte_to_utf16_col(line, token_start_in_line);
+                            let tok_end_u16 =
+                                byte_to_utf16_col(line, token_start_in_line + token_str.len());
+                            let range = Range::new(
+                                Position::new(line_idx as u32, tok_start_u16),
+                                Position::new(line_idx as u32, tok_end_u16),
+                            );
+
+                            raw_symbols.push(DocumentSymbol {
+                                name: var_name.to_string(),
+                                detail: Some(kw.to_string()),
+                                kind: SymbolKind::VARIABLE,
+                                tags: None,
+                                #[allow(deprecated)]
+                                deprecated: None,
+                                range,
+                                selection_range,
+                                children: None,
+                            });
+                        }
+                    }
+                    break;
+                }
+            }
+
+            if matched_decl_kw {
+                continue;
+            }
+
+            // 4. Check for Direct Variable Assignments: `VAR=...`, `VAR+=...`, `VAR[k]=...`
+            if let Some(eq_idx) = trimmed.find('=')
+                && eq_idx > 0
+                && !trimmed.starts_with("==")
+                && !trimmed[eq_idx..].starts_with("==")
+            {
+                let prev_char = trimmed.as_bytes().get(eq_idx.saturating_sub(1)).copied();
+                if !matches!(prev_char, Some(b'!' | b'<' | b'>' | b'=')) {
+                    let left_raw = &trimmed[..eq_idx];
+                    let left_no_plus = if let Some(stripped) = left_raw.strip_suffix('+') {
+                        stripped
+                    } else {
+                        left_raw
+                    };
+                    let left_no_bracket = if let Some(br) = left_no_plus.find('[') {
+                        &left_no_plus[..br]
+                    } else {
+                        left_no_plus
+                    };
+
+                    let var_name = left_no_bracket.trim();
+                    if !var_name.is_empty()
+                        && !var_name.chars().next().unwrap().is_ascii_digit()
+                        && var_name.chars().all(is_var_ident_char)
+                        && !is_reserved_keyword(var_name)
+                    {
+                        let name_start_byte = stmt_offset + trimmed.find(var_name).unwrap_or(0);
+                        let name_end_byte = name_start_byte + var_name.len();
+                        let sel_start_u16 = byte_to_utf16_col(line, name_start_byte);
+                        let sel_end_u16 = byte_to_utf16_col(line, name_end_byte);
+                        let selection_range = Range::new(
+                            Position::new(line_idx as u32, sel_start_u16),
+                            Position::new(line_idx as u32, sel_end_u16),
+                        );
+
+                        let stmt_start_u16 = byte_to_utf16_col(line, stmt_offset);
+                        let stmt_end_u16 =
+                            byte_to_utf16_col(line, stmt.start_byte + stmt.text.trim_end().len());
+                        let range = Range::new(
+                            Position::new(line_idx as u32, stmt_start_u16),
+                            Position::new(line_idx as u32, stmt_end_u16),
+                        );
+
+                        raw_symbols.push(DocumentSymbol {
+                            name: var_name.to_string(),
+                            detail: None,
+                            kind: SymbolKind::VARIABLE,
+                            tags: None,
+                            #[allow(deprecated)]
+                            deprecated: None,
+                            range,
+                            selection_range,
+                            children: None,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    build_symbol_tree(raw_symbols)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_uri() -> Url {
+        Url::parse("file:///test.zsh").unwrap()
+    }
+
+    #[test]
+    fn test_extract_symbols_empty_document() {
+        let uri = dummy_uri();
+        let symbols = extract_document_symbols("", &uri);
+        assert!(symbols.is_empty());
+    }
+
+    #[test]
+    fn test_extract_single_function_posix() {
+        let uri = dummy_uri();
+        let text = r#"
+my_func() {
+    echo "hello"
+}
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        assert_eq!(symbols.len(), 1);
+        let sym = &symbols[0];
+        assert_eq!(sym.name, "my_func");
+        assert_eq!(sym.kind, SymbolKind::FUNCTION);
+        assert_eq!(sym.selection_range.start.line, 1);
+        assert_eq!(sym.range.start.line, 1);
+        assert_eq!(sym.range.end.line, 3);
+    }
+
+    #[test]
+    fn test_extract_single_function_keyword() {
+        let uri = dummy_uri();
+        let text = r#"
+function fn_one {
+    echo 1
+}
+
+function fn_two() {
+    echo 2
+}
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        assert_eq!(symbols.len(), 2);
+        assert_eq!(symbols[0].name, "fn_one");
+        assert_eq!(symbols[0].kind, SymbolKind::FUNCTION);
+        assert_eq!(symbols[1].name, "fn_two");
+        assert_eq!(symbols[1].kind, SymbolKind::FUNCTION);
+    }
+
+    #[test]
+    fn test_extract_function_with_brace_on_next_line() {
+        let uri = dummy_uri();
+        let text = r#"
+func_split()
+{
+    local x=10
+}
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        assert_eq!(symbols.len(), 1);
+        let func = &symbols[0];
+        assert_eq!(func.name, "func_split");
+        assert_eq!(func.range.start.line, 1);
+        assert_eq!(func.range.end.line, 4);
+        let children = func.children.as_ref().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].name, "x");
+        assert_eq!(children[0].kind, SymbolKind::VARIABLE);
+    }
+
+    #[test]
+    fn test_extract_single_line_function() {
+        let uri = dummy_uri();
+        let text = r#"hello() { local msg="hi"; echo "$msg"; }"#;
+        let symbols = extract_document_symbols(text, &uri);
+        assert_eq!(symbols.len(), 1);
+        let func = &symbols[0];
+        assert_eq!(func.name, "hello");
+        assert_eq!(func.kind, SymbolKind::FUNCTION);
+        assert_eq!(func.range.start.line, 0);
+        assert_eq!(func.range.end.line, 0);
+        let children = func.children.as_ref().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].name, "msg");
+        assert_eq!(children[0].kind, SymbolKind::VARIABLE);
+    }
+
+    #[test]
+    fn test_extract_nested_functions_and_variables_hierarchy() {
+        let uri = dummy_uri();
+        let text = r#"
+GLOBAL_VAR="root"
+
+outer() {
+    local outer_var=1
+
+    inner() {
+        local inner_var=2
+    }
+
+    alias inside_alias='ls -la'
+    outer_var+=1
+}
+
+alias global_alias='git status'
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        assert_eq!(symbols.len(), 3); // GLOBAL_VAR, outer, global_alias
+
+        // 1. GLOBAL_VAR
+        assert_eq!(symbols[0].name, "GLOBAL_VAR");
+        assert_eq!(symbols[0].kind, SymbolKind::VARIABLE);
+
+        // 2. outer function
+        let outer = &symbols[1];
+        assert_eq!(outer.name, "outer");
+        assert_eq!(outer.kind, SymbolKind::FUNCTION);
+        let outer_children = outer.children.as_ref().unwrap();
+        assert_eq!(outer_children.len(), 4); // outer_var, inner, inside_alias, outer_var
+        assert_eq!(outer_children[0].name, "outer_var");
+        assert_eq!(outer_children[0].kind, SymbolKind::VARIABLE);
+
+        let inner = &outer_children[1];
+        assert_eq!(inner.name, "inner");
+        assert_eq!(inner.kind, SymbolKind::FUNCTION);
+        let inner_children = inner.children.as_ref().unwrap();
+        assert_eq!(inner_children.len(), 1);
+        assert_eq!(inner_children[0].name, "inner_var");
+        assert_eq!(inner_children[0].kind, SymbolKind::VARIABLE);
+
+        assert_eq!(outer_children[2].name, "inside_alias");
+        assert_eq!(outer_children[2].kind, SymbolKind::OPERATOR);
+
+        // 3. global_alias
+        assert_eq!(symbols[2].name, "global_alias");
+        assert_eq!(symbols[2].kind, SymbolKind::OPERATOR);
+    }
+
+    #[test]
+    fn test_extract_variable_declaration_keywords() {
+        let uri = dummy_uri();
+        let text = r#"
+export EXP_VAR="exported"
+typeset -g TYPESET_VAR="global"
+local LOC_VAR="local"
+declare -r CONST_VAR=42
+readonly RO_VAR="readonly"
+integer INT_VAR=100
+float FLOAT_VAR=3.14
+local MULTI_A=1 MULTI_B=2
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "EXP_VAR",
+                "TYPESET_VAR",
+                "LOC_VAR",
+                "CONST_VAR",
+                "RO_VAR",
+                "INT_VAR",
+                "FLOAT_VAR",
+                "MULTI_A",
+                "MULTI_B"
+            ]
+        );
+        for sym in &symbols {
+            assert_eq!(sym.kind, SymbolKind::VARIABLE);
+        }
+    }
+
+    #[test]
+    fn test_extract_alias_simple_and_global() {
+        let uri = dummy_uri();
+        let text = r#"
+alias ll='ls -la'
+alias -g G='| grep'
+alias gs='git status' gd='git diff'
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["ll", "G", "gs", "gd"]);
+        for sym in &symbols {
+            assert_eq!(sym.kind, SymbolKind::OPERATOR);
+        }
+    }
+
+    #[test]
+    fn test_extract_multibyte_and_emoji_coordinates() {
+        let uri = dummy_uri();
+        let text = r#"
+# Multibyte Kanji and surrogate pair emoji
+日本語関数() {
+    local 変数="値"
+    local 🍣="sushi"
+}
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        assert_eq!(symbols.len(), 1);
+        let func = &symbols[0];
+        assert_eq!(func.name, "日本語関数");
+        assert_eq!(func.kind, SymbolKind::FUNCTION);
+
+        let children = func.children.as_ref().unwrap();
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].name, "変数");
+        assert_eq!(children[0].kind, SymbolKind::VARIABLE);
+        assert_eq!(children[1].name, "🍣");
+        assert_eq!(children[1].kind, SymbolKind::VARIABLE);
+
+        // UTF-16 coordinate assertion for 🍣 (2 UTF-16 code units)
+        assert_eq!(
+            children[1].selection_range.end.character - children[1].selection_range.start.character,
+            2
+        );
+    }
+
+    #[test]
+    fn test_unclosed_function_tolerance() {
+        let uri = dummy_uri();
+        let text = r#"
+unclosed_func() {
+    local a=1
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        assert_eq!(symbols.len(), 1);
+        let func = &symbols[0];
+        assert_eq!(func.name, "unclosed_func");
+        let children = func.children.as_ref().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].name, "a");
+    }
+
+    #[test]
+    fn test_comments_and_strings_ignored() {
+        let uri = dummy_uri();
+        let text = r#"
+# ignored_func() { echo "fake"; }
+# export FAKE_VAR=1
+echo "func_in_string() { echo 1; }"
+echo "VAR=123"
+REAL_VAR="value"
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "REAL_VAR");
+    }
+
+    #[test]
+    fn test_quoted_braces_and_comments_in_function_body() {
+        let uri = dummy_uri();
+        let text = r#"
+complex_fn() {
+    echo "closing } inside quote"
+    echo 'another } quote'
+    # comment with } brace
+    local inner_var="ok"
+}
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        assert_eq!(symbols.len(), 1);
+        let func = &symbols[0];
+        assert_eq!(func.name, "complex_fn");
+        assert_eq!(func.range.start.line, 1);
+        assert_eq!(func.range.end.line, 6);
+        let children = func.children.as_ref().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].name, "inner_var");
+    }
+
+    #[test]
+    fn test_deep_nesting_three_levels() {
+        let uri = dummy_uri();
+        let text = r#"
+level1() {
+    local v1=1
+    level2() {
+        local v2=2
+        level3() {
+            local v3=3
+        }
+    }
+}
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        assert_eq!(symbols.len(), 1);
+        let l1 = &symbols[0];
+        assert_eq!(l1.name, "level1");
+        let l1_children = l1.children.as_ref().unwrap();
+        assert_eq!(l1_children.len(), 2); // v1, level2
+        assert_eq!(l1_children[0].name, "v1");
+
+        let l2 = &l1_children[1];
+        assert_eq!(l2.name, "level2");
+        let l2_children = l2.children.as_ref().unwrap();
+        assert_eq!(l2_children.len(), 2); // v2, level3
+        assert_eq!(l2_children[0].name, "v2");
+
+        let l3 = &l2_children[1];
+        assert_eq!(l3.name, "level3");
+        let l3_children = l3.children.as_ref().unwrap();
+        assert_eq!(l3_children.len(), 1);
+        assert_eq!(l3_children[0].name, "v3");
+    }
+
+    #[test]
+    fn test_array_and_indexed_assignments() {
+        let uri = dummy_uri();
+        let text = r#"
+ARR=(1 2 3)
+ARR+=(4 5)
+MAP[key]=value
+VAR+=suffix
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["ARR", "ARR", "MAP", "VAR"]);
+        for sym in &symbols {
+            assert_eq!(sym.kind, SymbolKind::VARIABLE);
+        }
+    }
+
+    #[test]
+    fn test_suffix_and_global_aliases() {
+        let uri = dummy_uri();
+        let text = r#"
+alias -s txt=nvim
+alias -g G='| grep'
+alias -r locked='echo locked'
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["txt", "G", "locked"]);
+        for sym in &symbols {
+            assert_eq!(sym.kind, SymbolKind::OPERATOR);
+        }
+    }
+
+    #[test]
+    fn test_special_function_names() {
+        let uri = dummy_uri();
+        let text = r#"
+my-kebab-func() { :; }
+prompt_pure_setup() { :; }
+ns::method() { :; }
+my.func() { :; }
+"#;
+        let symbols = extract_document_symbols(text, &uri);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "my-kebab-func",
+                "prompt_pure_setup",
+                "ns::method",
+                "my.func"
+            ]
+        );
+        for sym in &symbols {
+            assert_eq!(sym.kind, SymbolKind::FUNCTION);
+        }
+    }
+
+    #[test]
+    fn test_multi_statement_single_line() {
+        let uri = dummy_uri();
+        let text = r#"a=1; b=2; fn() { c=3; }; d=4"#;
+        let symbols = extract_document_symbols(text, &uri);
+        assert_eq!(symbols.len(), 4); // a, b, fn, d
+        assert_eq!(symbols[0].name, "a");
+        assert_eq!(symbols[0].kind, SymbolKind::VARIABLE);
+        assert_eq!(symbols[1].name, "b");
+        assert_eq!(symbols[1].kind, SymbolKind::VARIABLE);
+
+        assert_eq!(symbols[2].name, "fn");
+        assert_eq!(symbols[2].kind, SymbolKind::FUNCTION);
+        let fn_children = symbols[2].children.as_ref().unwrap();
+        assert_eq!(fn_children.len(), 1);
+        assert_eq!(fn_children[0].name, "c");
+        assert_eq!(fn_children[0].kind, SymbolKind::VARIABLE);
+
+        assert_eq!(symbols[3].name, "d");
+        assert_eq!(symbols[3].kind, SymbolKind::VARIABLE);
+    }
+}

--- a/tests/symbols_test.rs
+++ b/tests/symbols_test.rs
@@ -1,0 +1,478 @@
+mod common;
+
+use common::{TestClient, setup_server_mock as setup_server};
+use serde_json::json;
+use tower_lsp::lsp_types::{
+    ClientCapabilities, DidChangeConfigurationParams, DidOpenTextDocumentParams,
+    DocumentSymbolParams, DocumentSymbolResponse, InitializeParams, InitializedParams,
+    LogMessageParams, OneOf, SymbolKind, TextDocumentIdentifier, TextDocumentItem, Url,
+    notification::{DidChangeConfiguration, DidOpenTextDocument, Initialized, LogMessage},
+    request::{DocumentSymbolRequest, Initialize},
+};
+
+#[tokio::test]
+async fn test_symbols_capability_registered_on_initialize() {
+    let (mut client_stream, _server_handle) = setup_server();
+    let mut test_client = TestClient::new(&mut client_stream);
+
+    let initialize_params = InitializeParams {
+        process_id: Some(123),
+        root_uri: None,
+        capabilities: ClientCapabilities::default(),
+        ..Default::default()
+    };
+
+    let init_result = test_client
+        .send_request::<Initialize>(initialize_params)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        init_result.capabilities.document_symbol_provider,
+        Some(OneOf::Left(true))
+    );
+}
+
+#[tokio::test]
+async fn test_symbols_disabled_by_default() {
+    let (mut client_stream, _server_handle) = setup_server();
+    let mut test_client = TestClient::new(&mut client_stream);
+
+    let initialize_params = InitializeParams {
+        process_id: Some(123),
+        root_uri: None,
+        capabilities: ClientCapabilities::default(),
+        ..Default::default()
+    };
+
+    test_client
+        .send_request::<Initialize>(initialize_params)
+        .await
+        .unwrap();
+    test_client
+        .send_notification::<Initialized>(InitializedParams {})
+        .await;
+
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+
+    let doc_uri = Url::parse("file:///default_sym.zsh").unwrap();
+    let text = r#"
+my_func() {
+    local my_var="hello"
+}
+alias ll='ls -la'
+"#;
+
+    test_client
+        .send_notification::<DidOpenTextDocument>(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: doc_uri.clone(),
+                language_id: "zsh".to_string(),
+                version: 1,
+                text: text.to_string(),
+            },
+        })
+        .await;
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+
+    let sym_res = test_client
+        .send_request::<DocumentSymbolRequest>(DocumentSymbolParams {
+            text_document: TextDocumentIdentifier {
+                uri: doc_uri.clone(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .await
+        .unwrap();
+
+    assert!(sym_res.is_none());
+}
+
+#[tokio::test]
+async fn test_symbols_enabled_via_initialization_options() {
+    let (mut client_stream, _server_handle) = setup_server();
+    let mut test_client = TestClient::new(&mut client_stream);
+
+    let initialize_params = InitializeParams {
+        process_id: Some(123),
+        root_uri: None,
+        initialization_options: Some(json!({
+            "zshcs": {
+                "experimental": {
+                    "symbols": true
+                }
+            }
+        })),
+        capabilities: ClientCapabilities::default(),
+        ..Default::default()
+    };
+
+    test_client
+        .send_request::<Initialize>(initialize_params)
+        .await
+        .unwrap();
+    test_client
+        .send_notification::<Initialized>(InitializedParams {})
+        .await;
+
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+
+    let doc_uri = Url::parse("file:///enabled_sym.zsh").unwrap();
+    let text = r#"
+GLOBAL_VAR="test"
+
+hello() {
+    local msg="world"
+    echo "$msg"
+}
+
+alias gs='git status'
+"#;
+
+    test_client
+        .send_notification::<DidOpenTextDocument>(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: doc_uri.clone(),
+                language_id: "zsh".to_string(),
+                version: 1,
+                text: text.to_string(),
+            },
+        })
+        .await;
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+
+    let sym_res = test_client
+        .send_request::<DocumentSymbolRequest>(DocumentSymbolParams {
+            text_document: TextDocumentIdentifier {
+                uri: doc_uri.clone(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .await
+        .unwrap();
+
+    assert!(sym_res.is_some());
+    if let Some(DocumentSymbolResponse::Nested(symbols)) = sym_res {
+        assert_eq!(symbols.len(), 3); // GLOBAL_VAR, hello, gs
+
+        assert_eq!(symbols[0].name, "GLOBAL_VAR");
+        assert_eq!(symbols[0].kind, SymbolKind::VARIABLE);
+
+        assert_eq!(symbols[1].name, "hello");
+        assert_eq!(symbols[1].kind, SymbolKind::FUNCTION);
+        let children = symbols[1].children.as_ref().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].name, "msg");
+        assert_eq!(children[0].kind, SymbolKind::VARIABLE);
+
+        assert_eq!(symbols[2].name, "gs");
+        assert_eq!(symbols[2].kind, SymbolKind::OPERATOR);
+    } else {
+        panic!("Expected DocumentSymbolResponse::Nested");
+    }
+}
+
+#[tokio::test]
+async fn test_symbols_hierarchy_nested_functions_and_locals() {
+    let (mut client_stream, _server_handle) = setup_server();
+    let mut test_client = TestClient::new(&mut client_stream);
+
+    let initialize_params = InitializeParams {
+        process_id: Some(123),
+        root_uri: None,
+        initialization_options: Some(json!({
+            "zshcs": {
+                "experimental": {
+                    "symbols": true
+                }
+            }
+        })),
+        capabilities: ClientCapabilities::default(),
+        ..Default::default()
+    };
+
+    test_client
+        .send_request::<Initialize>(initialize_params)
+        .await
+        .unwrap();
+    test_client
+        .send_notification::<Initialized>(InitializedParams {})
+        .await;
+
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+
+    let doc_uri = Url::parse("file:///nested_sym.zsh").unwrap();
+    let text = r#"
+outer() {
+    local a=1
+
+    inner() {
+        local b=2
+    }
+
+    local c=3
+}
+"#;
+
+    test_client
+        .send_notification::<DidOpenTextDocument>(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: doc_uri.clone(),
+                language_id: "zsh".to_string(),
+                version: 1,
+                text: text.to_string(),
+            },
+        })
+        .await;
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+
+    let sym_res = test_client
+        .send_request::<DocumentSymbolRequest>(DocumentSymbolParams {
+            text_document: TextDocumentIdentifier {
+                uri: doc_uri.clone(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .await
+        .unwrap();
+
+    assert!(sym_res.is_some());
+    if let Some(DocumentSymbolResponse::Nested(symbols)) = sym_res {
+        assert_eq!(symbols.len(), 1);
+        let outer = &symbols[0];
+        assert_eq!(outer.name, "outer");
+        assert_eq!(outer.kind, SymbolKind::FUNCTION);
+
+        let outer_children = outer.children.as_ref().unwrap();
+        assert_eq!(outer_children.len(), 3); // a, inner, c
+
+        assert_eq!(outer_children[0].name, "a");
+        assert_eq!(outer_children[0].kind, SymbolKind::VARIABLE);
+
+        let inner = &outer_children[1];
+        assert_eq!(inner.name, "inner");
+        assert_eq!(inner.kind, SymbolKind::FUNCTION);
+        let inner_children = inner.children.as_ref().unwrap();
+        assert_eq!(inner_children.len(), 1);
+        assert_eq!(inner_children[0].name, "b");
+        assert_eq!(inner_children[0].kind, SymbolKind::VARIABLE);
+
+        assert_eq!(outer_children[2].name, "c");
+        assert_eq!(outer_children[2].kind, SymbolKind::VARIABLE);
+    } else {
+        panic!("Expected Nested document symbols");
+    }
+}
+
+#[tokio::test]
+async fn test_symbols_dynamic_toggle_via_did_change_configuration() {
+    let (mut client_stream, _server_handle) = setup_server();
+    let mut test_client = TestClient::new(&mut client_stream);
+
+    // 1. Initialize with default (disabled)
+    let initialize_params = InitializeParams {
+        process_id: Some(123),
+        root_uri: None,
+        capabilities: ClientCapabilities::default(),
+        ..Default::default()
+    };
+
+    test_client
+        .send_request::<Initialize>(initialize_params)
+        .await
+        .unwrap();
+    test_client
+        .send_notification::<Initialized>(InitializedParams {})
+        .await;
+
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+
+    let doc_uri = Url::parse("file:///toggle_sym.zsh").unwrap();
+    let text = r#"
+test_func() {
+    local v=100
+}
+"#;
+
+    test_client
+        .send_notification::<DidOpenTextDocument>(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: doc_uri.clone(),
+                language_id: "zsh".to_string(),
+                version: 1,
+                text: text.to_string(),
+            },
+        })
+        .await;
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+
+    // Disabled initially
+    let res_disabled = test_client
+        .send_request::<DocumentSymbolRequest>(DocumentSymbolParams {
+            text_document: TextDocumentIdentifier {
+                uri: doc_uri.clone(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .await
+        .unwrap();
+    assert!(res_disabled.is_none());
+
+    // 2. Enable dynamically via workspace/didChangeConfiguration
+    test_client
+        .send_notification::<DidChangeConfiguration>(DidChangeConfigurationParams {
+            settings: json!({
+                "zshcs": {
+                    "experimental": {
+                        "symbols": true
+                    }
+                }
+            }),
+        })
+        .await;
+
+    let res_enabled = test_client
+        .send_request::<DocumentSymbolRequest>(DocumentSymbolParams {
+            text_document: TextDocumentIdentifier {
+                uri: doc_uri.clone(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .await
+        .unwrap();
+    assert!(res_enabled.is_some());
+    if let Some(DocumentSymbolResponse::Nested(syms)) = res_enabled {
+        assert_eq!(syms.len(), 1);
+        assert_eq!(syms[0].name, "test_func");
+    }
+
+    // 3. Disable again dynamically
+    test_client
+        .send_notification::<DidChangeConfiguration>(DidChangeConfigurationParams {
+            settings: json!({
+                "zshcs": {
+                    "experimental": {
+                        "symbols": false
+                    }
+                }
+            }),
+        })
+        .await;
+
+    let res_disabled_again = test_client
+        .send_request::<DocumentSymbolRequest>(DocumentSymbolParams {
+            text_document: TextDocumentIdentifier {
+                uri: doc_uri.clone(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .await
+        .unwrap();
+    assert!(res_disabled_again.is_none());
+}
+
+#[tokio::test]
+async fn test_symbols_unopened_document_returns_none() {
+    let (mut client_stream, _server_handle) = setup_server();
+    let mut test_client = TestClient::new(&mut client_stream);
+
+    let initialize_params = InitializeParams {
+        process_id: Some(123),
+        root_uri: None,
+        initialization_options: Some(json!({
+            "zshcs": {
+                "experimental": {
+                    "symbols": true
+                }
+            }
+        })),
+        capabilities: ClientCapabilities::default(),
+        ..Default::default()
+    };
+
+    test_client
+        .send_request::<Initialize>(initialize_params)
+        .await
+        .unwrap();
+    test_client
+        .send_notification::<Initialized>(InitializedParams {})
+        .await;
+
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+
+    let unopened_uri = Url::parse("file:///nonexistent.zsh").unwrap();
+    let res = test_client
+        .send_request::<DocumentSymbolRequest>(DocumentSymbolParams {
+            text_document: TextDocumentIdentifier { uri: unopened_uri },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .await
+        .unwrap();
+
+    assert!(res.is_none());
+}
+
+#[tokio::test]
+async fn test_symbols_flat_and_nested_settings_variants() {
+    // Flat experimental format
+    let (mut client_stream, _server_handle) = setup_server();
+    let mut test_client = TestClient::new(&mut client_stream);
+
+    let initialize_params = InitializeParams {
+        process_id: Some(123),
+        root_uri: None,
+        initialization_options: Some(json!({
+            "experimental": {
+                "symbols": true
+            }
+        })),
+        capabilities: ClientCapabilities::default(),
+        ..Default::default()
+    };
+
+    test_client
+        .send_request::<Initialize>(initialize_params)
+        .await
+        .unwrap();
+    test_client
+        .send_notification::<Initialized>(InitializedParams {})
+        .await;
+
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+
+    let doc_uri = Url::parse("file:///flat_settings.zsh").unwrap();
+    test_client
+        .send_notification::<DidOpenTextDocument>(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: doc_uri.clone(),
+                language_id: "zsh".to_string(),
+                version: 1,
+                text: "fn() { :; }".to_string(),
+            },
+        })
+        .await;
+    let _: Option<LogMessageParams> = test_client.read_notification::<LogMessage>().await;
+
+    let res = test_client
+        .send_request::<DocumentSymbolRequest>(DocumentSymbolParams {
+            text_document: TextDocumentIdentifier { uri: doc_uri },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .await
+        .unwrap();
+    assert!(res.is_some());
+}


### PR DESCRIPTION
## Summary

This PR implements `textDocument/documentSymbol` (document symbols / outline tree) capabilities as an **experimental opt-in feature**:
1. **Opt-in Configuration (`src/config.rs` & `["zshcs"]["experimental"]["symbols"]`)**:
   - Disabled by default for zero runtime overhead.
   - Activated when `settings.zshcs.experimental.symbols = true` is configured via LSP `initializationOptions` or `workspace/didChangeConfiguration`.
2. **Symbol Extraction Engine (`src/symbols.rs` & `extract_document_symbols()`)**:
   - **Shell Functions (`SymbolKind::FUNCTION`)**: Extracts function definitions (`func() { ... }`, `function func { ... }`, `function func() { ... }`) with full scope `Range` and identifier `SelectionRange`.
   - **Hierarchical Nesting**: Uses a stack-based block tracker to nest local variables (`local`, `typeset`) and nested functions as `children` within their enclosing function scope.
   - **Variables & Parameters (`SymbolKind::VARIABLE`)**: Extracts global variables, `export`, `typeset -g`, direct assignments, and array declarations.
   - **Aliases (`SymbolKind::OPERATOR`)**: Extracts aliases (`alias name='...'`, `alias -g ...`, `alias -s ...`).
   - **UTF-16 & Unicode Safety**: Uses safe coordinate mapping supporting multi-byte CJK, emojis, and surrogate pairs.
3. **LSP Server Integration & Dynamic Settings (`src/server.rs`)**:
   - Registers `document_symbol_provider: Some(OneOf::Left(true))` in server capabilities.
   - Implements `document_symbol` handler returning `Ok(None)` when disabled.
4. **Documentation & Tests**:
   - Updates `README.md` (Neovim 0.11+ configuration) with sorted experimental options.
   - Updates `docs/ARCHITECTURE.md` with Document Symbol Subsystem architecture and sequence flow.
   - Adds `tests/symbols_test.rs` covering symbol hierarchies, dynamic configuration toggling, and edge cases.

## Changes

- **`src/config.rs`**:
  - Add `experimental_symbols` field and JSON extraction logic.
- **`src/symbols.rs`**:
  - Implement hierarchical document symbol extraction engine.
- **`src/server.rs`**:
  - Register document symbol capability and implement `document_symbol` LSP request handler.
- **`src/lib.rs`**:
  - Export `symbols` module.
- **`README.md` & `docs/ARCHITECTURE.md`**:
  - Document document symbol provider usage and architecture.
- **`tests/symbols_test.rs`**:
  - Add comprehensive integration tests.

## Verification

All checks passed:
- `nix build` -> OK
- `nix fmt` -> OK
- `cargo fmt --check` -> OK
- `cargo clippy --no-deps --all-targets -- -D warnings` -> OK (0 warnings)
- `cargo test --all-targets` -> OK (All 525+ tests passed)
- `zsh tests/zsh/run_tests.zsh` -> OK (All 12 tests passed)