### PR TITLE
refactor(nix): clean up flake.nix devShells and nativeBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,10 +33,6 @@
           ...
         }:
         let
-          pkgs = import inputs.nixpkgs {
-            inherit system;
-            overlays = [ (import inputs.rust-overlay) ];
-          };
           rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
           rustPlatform = pkgs.makeRustPlatform {
             cargo = rustToolchain;
@@ -44,6 +40,11 @@
           };
         in
         {
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ (import inputs.rust-overlay) ];
+          };
+
           treefmt.config = {
             projectRootFile = "flake.nix";
             programs = {
@@ -65,18 +66,17 @@
               lockFile = ./Cargo.lock;
             };
 
-            nativeBuildInputs = [
-              pkgs.zsh
-              pkgs.git
-              pkgs.man-db
-              pkgs.man-pages
+            nativeBuildInputs = with pkgs; [
+              git
+              man-db
+              man-pages
+              zsh
             ];
 
             preCheck = ''
               export HOME=$TMPDIR
               export MANPATH="${pkgs.git}/share/man:${pkgs.man-pages}/share/man:$MANPATH"
             '';
-
           };
 
           apps.default = {
@@ -88,8 +88,6 @@
           devShells.default = pkgs.mkShell {
             packages = with pkgs; [
               rustToolchain
-              openssl
-              pkg-config
               zsh
             ];
 


### PR DESCRIPTION
## Summary

This PR cleans up and refactors `flake.nix`:
- **Overlay Refactoring**: Use `_module.args.pkgs` instead of local `pkgs` shadowing in `perSystem` for a cleaner, idiomatic flake-parts setup.
- **`devShells` Optimization**: Removed unused `openssl` and `pkg-config` packages (the project has no native C dependencies).
- **`nativeBuildInputs` Cleanup**: Declared `nativeBuildInputs` using `with pkgs;` and sorted the tool list alphabetically (`git`, `man-db`, `man-pages`, `zsh`).

## Verification

- `nix fmt -- --ci`: Passed
- `nix flake check`: Passed
- `nix build`: Passed
- `nix develop` test suite execution: All Rust and Zsh unit tests passed
- Verified that `rust-toolchain.toml` (Rust 1.98.0) is properly used in both `nix build` and `devShells`.